### PR TITLE
Remove duplicated funding check comment

### DIFF
--- a/src/bots/pfpl/strategy.py
+++ b/src/bots/pfpl/strategy.py
@@ -202,7 +202,6 @@ class PFPLStrategy:
             return
         now = time.time()
         # 0) --- Funding 直前クローズ判定 -----------------------------------
-        # 0) --- Funding 直前クローズ判定 -----------------------------------
         if self._should_close_before_funding(now):
             asyncio.create_task(self._close_all_positions())
             return  # 今回の evaluate はここで終了


### PR DESCRIPTION
## Summary
- clean up PFPLStrategy.evaluate by dropping a repeated funding-check comment

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'hl_core'; websockets InvalidProxyStatus 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c19e246360832980e00e83577a67d3