### PR TITLE
Use certifi CA bundle for tests

### DIFF
--- a/test_api.py
+++ b/test_api.py
@@ -1,5 +1,12 @@
+import os
+
 import anyio
+import certifi
 from hl_core.api import HTTPClient
+
+# Ensure HTTPClient uses certifi's CA bundle for SSL verification.
+os.environ.setdefault("SSL_CERT_FILE", certifi.where())
+os.environ.setdefault("REQUESTS_CA_BUNDLE", certifi.where())
 
 
 async def main() -> None:

--- a/test_ws.py
+++ b/test_ws.py
@@ -1,11 +1,17 @@
 import json
+import ssl
+
 import anyio
+import certifi
 import websockets
 
 
 async def main():
+    # Use certifi's CA bundle to validate the WebSocket TLS handshake.
+    _sslctx = ssl.create_default_context(cafile=certifi.where())
+
     async with websockets.connect(
-        "wss://api.hyperliquid.xyz/ws", ping_interval=None
+        "wss://api.hyperliquid.xyz/ws", ping_interval=None, ssl=_sslctx
     ) as ws:
         await ws.send(
             json.dumps({"method": "subscribe", "subscription": {"type": "allMids"}})

--- a/test_ws_loop.py
+++ b/test_ws_loop.py
@@ -1,5 +1,15 @@
+import functools
+import ssl
+
 import anyio
+import certifi
+import websockets
 from hl_core.api import WSClient
+
+# Ensure websockets uses certifi's CA bundle for TLS verification.
+_sslctx = ssl.create_default_context(cafile=certifi.where())
+_orig_connect = websockets.connect
+websockets.connect = functools.partial(_orig_connect, ssl=_sslctx)
 
 
 class DemoWS(WSClient):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+# Ensure consistent SSL certificate verification using certifi's CA bundle.
+import os, certifi  # noqa: F401
+
+# Use certifi for OpenSSL-based libraries (requests, httpx, websockets, etc.).
+os.environ.setdefault("SSL_CERT_FILE", certifi.where())
+os.environ.setdefault("REQUESTS_CA_BUNDLE", certifi.where())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 # Ensure consistent SSL certificate verification using certifi's CA bundle.
-import os, certifi  # noqa: F401
+import os
+import certifi
 
 # Use certifi for OpenSSL-based libraries (requests, httpx, websockets, etc.).
 os.environ.setdefault("SSL_CERT_FILE", certifi.where())


### PR DESCRIPTION
## Summary
- ensure tests use certifi's CA bundle for HTTP and WebSocket connections
- add certifi-backed SSL contexts for WebSocket demo scripts

## Testing
- `poetry run pytest tests -q` (fails: ModuleNotFoundError for hl_core and bots)
- `poetry run python test_api.py` (fails: ModuleNotFoundError: anyio)
- `poetry run python test_ws.py` (fails: ModuleNotFoundError: anyio)
- `poetry run python test_ws_loop.py` (fails: ModuleNotFoundError: anyio)


------
https://chatgpt.com/codex/tasks/task_e_68c6393285508329b4d418e5c600ed68