### PR TITLE
Fix HTTPClient test to use certificate verification

### DIFF
--- a/test_api.py
+++ b/test_api.py
@@ -2,6 +2,7 @@ import os
 
 import anyio
 import certifi
+import httpx
 import pytest
 from hl_core.api import HTTPClient
 
@@ -11,14 +12,16 @@ os.environ.setdefault("REQUESTS_CA_BUNDLE", certifi.where())
 
 
 async def main() -> None:
-    cli = HTTPClient(base_url="https://api.hyperliquid.xyz", verify=False)
-    data = await cli.post("info", data={"type": "meta"})  # 実在パスに合わせて
-    print("sample keys:", list(data)[:3])
-    await cli.close()
+    cli = HTTPClient(base_url="https://api.hyperliquid.xyz", verify=certifi.where())
+    try:
+        data = await cli.post("info", data={"type": "meta"})  # 実在パスに合わせて
+        print("sample keys:", list(data)[:3])
+    finally:
+        await cli.close()
 
 
 def test_http_client_meta() -> None:
     try:
         anyio.run(main)
-    except Exception as exc:  # pragma: no cover - network dependent
-        pytest.skip(f"HTTP request failed: {exc}")
+    except httpx.NetworkError as exc:  # pragma: no cover - network dependent
+        pytest.skip(f"Network unavailable: {exc}")


### PR DESCRIPTION
## Summary
- ensure HTTPClient test uses certificate bundle instead of `verify=False`
- skip HTTPClient test when network access is unavailable

## Testing
- `pre-commit run --files test_api.py`
- `pytest test_api.py::test_http_client_meta -vv`


------
https://chatgpt.com/codex/tasks/task_e_68c6df98113083299253971d4f6217a5