### PR TITLE
Guard PFPLStrategy logger initialisation

### DIFF
--- a/tests/unit/test_pfpl_init.py
+++ b/tests/unit/test_pfpl_init.py
@@ -1,5 +1,6 @@
 # tests/unit/test_pfpl_init.py
 from asyncio import Semaphore
+import logging
 from bots.pfpl import PFPLStrategy
 
 
@@ -11,5 +12,11 @@ def test_init(monkeypatch):
     # ── セマフォは 1 で十分 ──
     sem = Semaphore(1)
 
-    # 例外が出なければ成功
+    # 初回初期化でハンドラが増える
+    before = len(logging.getLogger().handlers)
     PFPLStrategy(config={}, semaphore=sem)
+    after_first = len(logging.getLogger().handlers)
+    # 2 度目でもハンドラが増えないことを確認
+    PFPLStrategy(config={}, semaphore=sem)
+    after_second = len(logging.getLogger().handlers)
+    assert after_first == after_second > before


### PR DESCRIPTION
## Summary
- initialise logging when PFPLStrategy is constructed
- prevent duplicate log handlers for the same trading pair
- add regression test to ensure logger setup runs only once per process

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6dfea381083299c9f4513e6cad9fa