### PR TITLE
Ensure websocket tests use verified SSL context

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,8 @@
+# Hyperliquid
+
+Integration tests connect to the Hyperliquid API over HTTPS and WebSockets.
+To verify the SSL certificates presented by the servers, the tests rely on
+[`certifi`](https://pypi.org/project/certifi/) for a trusted Certificate
+Authority bundle. Ensure `certifi` is installed so these connections can be
+established securely.
+

--- a/test_ws.py
+++ b/test_ws.py
@@ -6,9 +6,15 @@ import certifi
 import pytest
 import websockets
 
+# Tests use certifi's CA bundle so websocket connections verify server
+# certificates instead of disabling SSL verification.
+
 
 async def main() -> None:
-    """Subscribe to the allMids feed using a verified SSL context."""
+    """Subscribe to the allMids feed using a verified SSL context.
+
+    Requires certifi to supply trusted root certificates.
+    """
     sslctx = ssl.create_default_context(cafile=certifi.where())
 
     async with websockets.connect(


### PR DESCRIPTION
## Summary
- document that integration tests require `certifi` for trusted SSL certificates
- explicitly note `certifi` usage in websocket test and README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6f43d97f483299aad1778d67b5f10