### PR TITLE
Use logging for websocket debug output

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -6,6 +6,7 @@ verification when available.
 
 from __future__ import annotations
 
+import logging
 import os
 import sys
 from pathlib import Path
@@ -22,3 +23,5 @@ if str(SRC_PATH) not in sys.path:
 # variables (e.g. requests, httpx, websockets).
 os.environ.setdefault("SSL_CERT_FILE", certifi.where())
 os.environ.setdefault("REQUESTS_CA_BUNDLE", certifi.where())
+
+logging.basicConfig(level=logging.DEBUG)

--- a/test_ws.py
+++ b/test_ws.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import ssl
 
 import anyio
@@ -20,7 +21,7 @@ async def main() -> None:
 
         for _ in range(3):  # ここを追加 —— 3 件だけ受信
             msg = await ws.recv()
-            print("recv:", msg[:200], "…")
+            logging.debug("recv: %s …", msg[:200])
 
 
 def test_ws_subscription() -> None:


### PR DESCRIPTION
## Summary
- replace print call with logging.debug in websocket test
- configure logging for test suite

## Testing
- `pre-commit run --files conftest.py test_ws.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c6f44565c883299016148b4aa7899c