### PR TITLE
Restore live WebSocket subscription test

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,3 +41,8 @@ black = "^25.1.0"
 mypy = "^1.16.1"
 pre-commit = "^4.2.0"
 hyperliquid-python-sdk = "^0.4.0"
+
+[tool.pytest.ini_options]
+markers = [
+    "network: tests that require network access",
+]

--- a/test_ws.py
+++ b/test_ws.py
@@ -1,22 +1,76 @@
-"""Tests for WebSocket subscription against the live Hyperliquid server."""
+"""Tests for WebSocket subscription using both mock and live servers."""
 
 from __future__ import annotations
 
 import json
 import ssl
+from threading import Thread
 
 import anyio
 import certifi
 import pytest
 import websockets
-
-# Tests use certifi's CA bundle so websocket connections verify server
-# certificates instead of disabling SSL verification.
+from websockets.sync.server import serve
 
 
-# 検証済みのSSLコンテキストでHyperliquid WSに接続し、
-# "allMids" チャネルの実データだけを3件集めて返す（確認用の軽量ヘルパ）
-async def main() -> list[dict[str, object]]:
+@pytest.fixture
+def mock_hyperliquid_ws_server() -> str:
+    """Spin up a local WebSocket server that mimics Hyperliquid responses."""
+
+    def handler(ws) -> None:  # pragma: no cover - exercised indirectly
+        raw = ws.recv()
+        request = json.loads(raw)
+        ws.send(
+            json.dumps(
+                {
+                    "channel": "subscriptionResponse",
+                    "data": request,
+                }
+            )
+        )
+        for i in range(3):
+            ws.send(
+                json.dumps(
+                    {
+                        "channel": "allMids",
+                        "data": {"sequence": i},
+                    }
+                )
+            )
+
+    server = serve(handler, "localhost", 0)
+    thread = Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    port = server.socket.getsockname()[1]
+    try:
+        yield f"ws://localhost:{port}"
+    finally:
+        server.shutdown()
+        thread.join(timeout=1)
+
+
+async def _subscriber(url: str) -> None:
+    async with websockets.connect(url, ping_interval=None) as ws:
+        await ws.send(
+            json.dumps({"method": "subscribe", "subscription": {"type": "allMids"}})
+        )
+
+        ack = await ws.recv()
+        ack_payload = json.loads(ack)
+        assert ack_payload.get("channel") == "subscriptionResponse"
+
+        for expected_sequence in range(3):
+            msg = await ws.recv()
+            payload = json.loads(msg)
+            assert payload == {
+                "channel": "allMids",
+                "data": {"sequence": expected_sequence},
+            }
+
+
+async def _collect_live_all_mids() -> list[dict[str, object]]:
+    """Subscribe to the live Hyperliquid WS and collect a few allMids messages."""
+
     sslctx = ssl.create_default_context(cafile=certifi.where())
 
     async with anyio.fail_after(5):
@@ -35,10 +89,14 @@ async def main() -> list[dict[str, object]]:
             return messages
 
 
+def test_ws_subscription_mock(mock_hyperliquid_ws_server: str) -> None:
+    anyio.run(_subscriber, mock_hyperliquid_ws_server)
+
+
 @pytest.mark.network
-def test_ws_subscription() -> None:
+def test_ws_subscription_live() -> None:
     try:
-        messages = anyio.run(main)
+        messages = anyio.run(_collect_live_all_mids)
     except Exception as exc:  # pragma: no cover - network dependent
         pytest.skip(f"websocket connection failed: {exc}")
     assert len(messages) == 3

--- a/test_ws.py
+++ b/test_ws.py
@@ -1,5 +1,8 @@
-import json
+"""Tests for WebSocket subscription against the live Hyperliquid server."""
 
+from __future__ import annotations
+
+import json
 import ssl
 
 import anyio
@@ -10,10 +13,10 @@ import websockets
 # Tests use certifi's CA bundle so websocket connections verify server
 # certificates instead of disabling SSL verification.
 
+
 # 検証済みのSSLコンテキストでHyperliquid WSに接続し、
 # "allMids" チャネルの実データだけを3件集めて返す（確認用の軽量ヘルパ）
 async def main() -> list[dict[str, object]]:
-
     sslctx = ssl.create_default_context(cafile=certifi.where())
 
     async with anyio.fail_after(5):
@@ -32,7 +35,7 @@ async def main() -> list[dict[str, object]]:
             return messages
 
 
-
+@pytest.mark.network
 def test_ws_subscription() -> None:
     try:
         messages = anyio.run(main)

--- a/test_ws_loop.py
+++ b/test_ws_loop.py
@@ -1,3 +1,5 @@
+"""Tests for WebSocket loop subscription against the live Hyperliquid server."""
+
 import functools
 import ssl
 
@@ -30,6 +32,7 @@ async def main() -> None:
         await ws.close()
 
 
+@pytest.mark.network
 def test_ws_loop_subscription() -> None:
     try:
         anyio.run(main)


### PR DESCRIPTION
## Summary
- restore the WebSocket subscription test to connect to the live Hyperliquid endpoint with certificate validation
- mark the restored live test with the `network` marker so it is easy to skip in offline environments

## Testing
- `poetry run black --check .`
- `pytest test_ws.py::test_ws_subscription -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6fc73a96c8329bd8c68d596d38b01