### PR TITLE
Add settings loader and Hyperliquid client helpers

### DIFF
--- a/src/hl_core/config.py
+++ b/src/hl_core/config.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import os
+from typing import Literal, Optional
+
+from dotenv import load_dotenv
+from pydantic import BaseModel, field_validator
+
+
+def load_env_file() -> None:
+    load_dotenv(override=True)
+
+
+class Settings(BaseModel):
+    dry_run: bool = True
+    database_url: str = "sqlite:///bot.db"
+    network: Literal["mainnet", "testnet"] = "testnet"
+    account_address: Optional[str] = None
+    private_key: Optional[str] = None
+    log_level: str = "INFO"
+
+    @field_validator("dry_run", mode="before")
+    def _coerce_bool(cls, v):
+        if isinstance(v, bool):
+            return v
+        if v is None:
+            return True
+        return str(v).strip().lower() in {"1", "true", "yes", "on"}
+
+    @field_validator("network", mode="before")
+    def _norm_network(cls, v):
+        if not v:
+            return "testnet"
+        s = str(v).strip().lower()
+        if s in {"mainnet", "main", "prod", "production"}:
+            return "mainnet"
+        return "testnet"
+
+
+def load_settings() -> Settings:
+    load_env_file()
+    return Settings(
+        dry_run=os.getenv("DRY_RUN", "true"),
+        database_url=os.getenv("DATABASE_URL", "sqlite:///bot.db"),
+        network=os.getenv("NETWORK", "testnet"),
+        account_address=os.getenv("HL_ACCOUNT_ADDRESS"),
+        private_key=os.getenv("HL_PRIVATE_KEY"),
+        log_level=os.getenv("LOG_LEVEL", "INFO"),
+    )
+
+
+def require_live_creds(settings: Settings) -> None:
+    if not settings.dry_run:
+        if not settings.private_key or not settings.account_address:
+            raise ValueError(
+                "Live mode requires HL_PRIVATE_KEY and HL_ACCOUNT_ADDRESS in .env"
+            )
+
+
+def mask_secret(value: Optional[str], show: int = 6) -> str:
+    if not value:
+        return ""
+    if len(value) <= show * 2:
+        return "*" * len(value)
+    return value[:show] + "…" + value[-show:]

--- a/src/hl_core/hl_client.py
+++ b/src/hl_core/hl_client.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from typing import Optional, Tuple
+
+from eth_account import Account
+from eth_account.signers.local import LocalAccount
+from hyperliquid.exchange import Exchange
+from hyperliquid.info import Info
+from hyperliquid.utils import constants
+
+from .config import Settings, mask_secret, require_live_creds
+
+
+def get_base_url(network: str) -> str:
+    return constants.MAINNET_API_URL if network == "mainnet" else constants.TESTNET_API_URL
+
+
+def make_account(settings: Settings) -> Optional[LocalAccount]:
+    if not settings.private_key:
+        return None
+    return Account.from_key(settings.private_key)
+
+
+def make_clients(settings: Settings) -> Tuple[Info, Optional[Exchange], str]:
+    base_url = get_base_url(settings.network)
+    info = Info(base_url, skip_ws=True)
+    account = make_account(settings)
+
+    resolved_address = (settings.account_address or (account.address if account else "")) or ""
+
+    if account and settings.account_address and settings.account_address.lower() != account.address.lower():
+        print(
+            f"[warn] HL_ACCOUNT_ADDRESS と秘密鍵由来のアドレスが不一致です。"
+            f" 使用候補: {account.address} (pk={mask_secret(settings.private_key)})"
+        )
+
+    exchange = Exchange(account, base_url) if account else None
+    return info, exchange, resolved_address
+
+
+def safe_market_open(exchange: Exchange, coin: str, is_buy: bool, sz: float, settings: Settings):
+    if settings.dry_run:
+        print(f"[dry-run] market_open({coin}, buy={is_buy}, sz={sz}) はブロックされました（DRY_RUN=true）")
+        return {"status": "dry-run"}
+    require_live_creds(settings)
+    return exchange.market_open(coin, is_buy, sz)


### PR DESCRIPTION
## Summary
- add a Pydantic-backed settings loader to normalize env configuration for the bot
- add Hyperliquid client helpers that initialize Info/Exchange and guard live orders

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68caec3da0008329b5ed2f52f46e841f