### PR TITLE
Fix websocket subscriptions and dynamic coin handling

### DIFF
--- a/src/bots/pfpl/strategy.py
+++ b/src/bots/pfpl/strategy.py
@@ -82,6 +82,8 @@ class PFPLStrategy:
 
         # ── ② 通貨ペア・Semaphore 初期化 ─────────────────
         self.symbol: str = self.config.get("target_symbol", "ETH-PERP")
+        sym_parts = self.symbol.split("-", 1)
+        self.base_coin: str = sym_parts[0] if sym_parts else self.symbol
 
         max_ops = int(self.config.get("max_order_per_sec", 3))  # 1 秒あたり発注上限
         self.sem: asyncio.Semaphore = semaphore or asyncio.Semaphore(max_ops)
@@ -205,22 +207,36 @@ class PFPLStrategy:
         if ch == "allMids":  # 板 mid 群
             self.mid = Decimal(msg["data"]["mids"]["@1"])
         elif ch == "indexPrices":  # インデックス価格
-            self.idx = Decimal(msg["data"]["prices"]["ETH"])
+            prices = (msg.get("data") or {}).get("prices", {})
+            price_val = prices.get(self.base_coin)
+            if price_val is not None:
+                self.idx = Decimal(str(price_val))
         elif ch == "oraclePrices":  # オラクル価格
-            self.ora = Decimal(msg["data"]["prices"]["ETH"])
+            prices = (msg.get("data") or {}).get("prices", {})
+            price_val = prices.get(self.base_coin)
+            if price_val is not None:
+                self.ora = Decimal(str(price_val))
         elif msg.get("channel") == "fundingInfo":
             data = msg.get("data", {})
-            next_ts = data.get("nextFundingTime")
-            if next_ts is None:
+            next_ts = data.get("nextFundingTime") if isinstance(data, dict) else None
+            if next_ts is None and isinstance(data, dict):
                 info = data.get(self.symbol)
-                if info:
+                if isinstance(info, dict):
                     next_ts = info.get("nextFundingTime")
+            if next_ts is None and isinstance(data, dict):
+                base_info = data.get(self.base_coin)
+                if isinstance(base_info, dict):
+                    next_ts = base_info.get("nextFundingTime")
             if next_ts is not None:
                 self.next_funding_ts = float(next_ts)
                 logger.debug("fundingInfo: next @ %s", self.next_funding_ts)
 
         # fair が作れれば評価へ
-        if self.mid and self.idx and self.ora:
+        if (
+            self.mid is not None
+            and self.idx is not None
+            and self.ora is not None
+        ):
             self.fair = (self.idx + self.ora) / 2  # ★ 平均で公正価格
             self.evaluate()
 

--- a/src/hl_core/api/__init__.py
+++ b/src/hl_core/api/__init__.py
@@ -56,7 +56,8 @@ class WSClient:
         self.retry_sec = retry_sec
 
         self._ws: Any | None = None
-        self._subs: set[str] = set()  # set に統一
+        # WebSocket 購読情報を JSON 文字列で保持（reconnect 時に再送）
+        self._subs: set[str] = set()
 
         # コールバック（デフォルトは no-op）
         self.on_message: Callable[[dict[str, Any]], Awaitable[None] | None] = (
@@ -82,10 +83,17 @@ class WSClient:
                     self._ready.set()  # ★ open を通知
 
                     # 過去の購読を復元
-                    for ch in self._subs:
+                    for sub_json in self._subs:
+                        try:
+                            subscription = json.loads(sub_json)
+                        except json.JSONDecodeError:
+                            logger.warning(
+                                "Skip invalid stored subscription: %s", sub_json
+                            )
+                            continue
                         await ws.send(
                             json.dumps(
-                                {"method": "subscribe", "subscription": {"type": ch}}
+                                {"method": "subscribe", "subscription": subscription}
                             )
                         )
 
@@ -105,25 +113,45 @@ class WSClient:
         await self._ready.wait()
 
     # ── 4. subscribe ────────────────────────────────────────────
-    async def subscribe(self, feed_type: str) -> None:
+    @staticmethod
+    def _normalize_subscription(
+        subscription: str | dict[str, Any]
+    ) -> tuple[dict[str, Any], str, str]:
+        """返却: (payload, key, label)"""
+
+        if isinstance(subscription, str):
+            payload: dict[str, Any] = {"type": subscription}
+            label = subscription
+        elif isinstance(subscription, dict):
+            payload = dict(subscription)
+            label = str(payload.get("type", payload))
+        else:  # pragma: no cover - 型ヒントがあるため通常到達しない
+            raise TypeError(f"Unsupported subscription type: {type(subscription)!r}")
+
+        key = json.dumps(payload, sort_keys=True)
+        return payload, key, label
+
+    async def subscribe(self, subscription: str | dict[str, Any]) -> None:
+        payload, sub_key, label = self._normalize_subscription(subscription)
+
         # まだ接続完了していない場合は待つ
         if not self._ready.is_set():
-            logger.warning("WS not ready; skip subscribe(%s)", feed_type)
+            logger.warning("WS not ready; skip subscribe(%s)", label)
             return
 
-        if feed_type in self._subs:
+        if sub_key in self._subs:
             return  # 既に購読済み
 
         ws = self._ws
         if ws is None:
-            logger.warning("WS handle missing; skip subscribe(%s)", feed_type)
+            logger.warning("WS handle missing; skip subscribe(%s)", label)
             return
 
         await ws.send(
-            json.dumps({"method": "subscribe", "subscription": {"type": feed_type}})
+            json.dumps({"method": "subscribe", "subscription": payload})
         )
-        self._subs.add(feed_type)
-        logger.debug("Subscribed %s", feed_type)
+        self._subs.add(sub_key)
+        logger.debug("Subscribed %s", label)
 
     # ─────────────────────────────────────────────────────────────
     async def _listen(self) -> None:


### PR DESCRIPTION
## Summary
- allow `WSClient.subscribe` to accept dictionary payloads and persist subscriptions for reconnects
- derive per-symbol base coins in `run_bot.py` and subscribe with the coin-specific websocket payloads Hyperliquid expects
- read index/oracle/funding updates by base coin inside `PFPLStrategy` so downstream logic receives the feeds

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cec2c2bb1c83299177424993f57135