### PR TITLE
Fix PFPL position refresh to respect configured base coin

### DIFF
--- a/src/bots/pfpl/strategy.py
+++ b/src/bots/pfpl/strategy.py
@@ -180,18 +180,18 @@ class PFPLStrategy:
     # ── src/bots/pfpl/strategy.py ──
     async def _refresh_position(self) -> None:
         """
-        現在の ETH-PERP 建玉 USD を self.pos_usd に反映。
+        現在の建玉 USD を self.pos_usd に反映。
         perpPositions が無い口座でも落ちない。
         """
         try:
             state = self.exchange.info.user_state(self.account)
 
-            # ―― ETH の perp 建玉を抽出（無い場合は None）
+            # ―― 対象コインの perp 建玉を抽出（無い場合は None）
             perp_pos = next(
                 (
                     p
                     for p in state.get("perpPositions", [])  # ← 🔑 get(..., [])
-                    if p["position"]["coin"] == "ETH"
+                    if p["position"]["coin"] == self.base_coin
                 ),
                 None,
             )

--- a/tests/unit/test_pfpl_init.py
+++ b/tests/unit/test_pfpl_init.py
@@ -1,6 +1,8 @@
 # tests/unit/test_pfpl_init.py
 from asyncio import Semaphore
+from decimal import Decimal
 import logging
+import pytest
 from bots.pfpl import PFPLStrategy
 
 
@@ -20,3 +22,27 @@ def test_init(monkeypatch):
     PFPLStrategy(config={}, semaphore=sem)
     after_second = len(logging.getLogger().handlers)
     assert after_first == after_second > before
+
+
+@pytest.mark.asyncio
+async def test_refresh_position_uses_base_coin(monkeypatch):
+    monkeypatch.setenv("HL_ACCOUNT_ADDR", "0xTEST")
+    monkeypatch.setenv("HL_API_SECRET", "0x" + "11" * 32)
+
+    strategy = PFPLStrategy(config={}, semaphore=Semaphore(1))
+    strategy.base_coin = "SOL"
+    strategy.symbol = "SOL-PERP"
+
+    def fake_user_state(account: str):
+        return {
+            "perpPositions": [
+                {"position": {"coin": "ETH", "sz": "1", "entryPx": "100"}},
+                {"position": {"coin": "SOL", "sz": "2", "entryPx": "3"}},
+            ]
+        }
+
+    monkeypatch.setattr(strategy.exchange.info, "user_state", fake_user_state)
+
+    await strategy._refresh_position()
+
+    assert strategy.pos_usd == Decimal("6")


### PR DESCRIPTION
## Summary
- ensure PFPL position refresh filters perp positions by the configured base coin instead of a hard-coded symbol
- add a regression test covering USD exposure updates for a non-ETH market

## Testing
- pytest tests/unit/test_pfpl_init.py

------
https://chatgpt.com/codex/tasks/task_e_68d00aa62b3c832984c8fbfd3b9e39ff