### PR TITLE
Log signed PFPL diff and add coverage test

### DIFF
--- a/src/bots/pfpl/strategy.py
+++ b/src/bots/pfpl/strategy.py
@@ -338,8 +338,10 @@ class PFPLStrategy:
         if mid is None or fair is None:
             return  # データが揃っていない
 
-        abs_diff = abs(fair - mid)  # USD 差
-        pct_diff = abs_diff / mid * Decimal("100")  # 乖離率 %
+        diff = fair - mid  # USD 差（符号付き）
+        diff_pct = diff / mid * Decimal("100")  # 乖離率 %（符号付き）
+        abs_diff = abs(diff)
+        pct_diff = abs(diff_pct)
 
         # ④ 閾値判定
         th_abs = Decimal(str(self.config.get("threshold", "1.0")))  # USD
@@ -347,9 +349,9 @@ class PFPLStrategy:
         mode = self.config.get("mode", "both")  # both / either
 
         logger.debug(
-            "signal: abs=%.6f pct=%.6f thr=%.6f thr_pct=%.6f pos_usd=%.2f order_usd=%.2f dry_run=%s",
-            abs_diff,
-            pct_diff,
+            "signal: diff=%+.6f diff_pct=%+.6f thr=%.6f thr_pct=%.6f pos_usd=%+.2f order_usd=%.2f dry_run=%s",
+            diff,
+            diff_pct,
             th_abs,
             th_pct,
             self.pos_usd,

--- a/tests/unit/test_pfpl_evaluate.py
+++ b/tests/unit/test_pfpl_evaluate.py
@@ -1,0 +1,58 @@
+# tests/unit/test_pfpl_evaluate.py
+from asyncio import Semaphore
+from decimal import Decimal
+import logging
+
+import pytest
+
+from bots.pfpl import PFPLStrategy
+
+
+@pytest.fixture
+def strategy(monkeypatch: pytest.MonkeyPatch) -> PFPLStrategy:
+    monkeypatch.setenv("HL_ACCOUNT_ADDR", "0xTEST")
+    monkeypatch.setenv("HL_API_SECRET", "0x" + "11" * 32)
+    strat = PFPLStrategy(config={}, semaphore=Semaphore(1))
+    strat.config["threshold"] = "200"
+    strat.config["threshold_pct"] = "200"
+    strat.mid = Decimal("100")
+    yield strat
+
+    PFPLStrategy._FILE_HANDLERS.discard(strat.symbol)
+    root_logger = logging.getLogger()
+    for handler in list(root_logger.handlers):
+        filename = getattr(handler, "baseFilename", "")
+        if isinstance(handler, logging.FileHandler) and filename.endswith(
+            f"strategy_{strat.symbol}.log"
+        ):
+            root_logger.removeHandler(handler)
+            handler.close()
+
+
+def test_evaluate_logs_signed_diff(strategy: PFPLStrategy, caplog: pytest.LogCaptureFixture):
+    caplog.set_level(logging.DEBUG, logger="bots.pfpl.strategy")
+    caplog.clear()
+
+    strategy.fair = Decimal("101")
+
+    strategy.evaluate()
+
+    assert any(
+        record.levelno == logging.DEBUG
+        and "diff=+1.000000" in record.message
+        and "diff_pct=+1.000000" in record.message
+        for record in caplog.records
+    ), "expected positive diff log"
+
+    caplog.clear()
+
+    strategy.fair = Decimal("99")
+
+    strategy.evaluate()
+
+    assert any(
+        record.levelno == logging.DEBUG
+        and "diff=-1.000000" in record.message
+        and "diff_pct=-1.000000" in record.message
+        for record in caplog.records
+    ), "expected negative diff log"

--- a/tests/unit/test_pfpl_evaluate.py
+++ b/tests/unit/test_pfpl_evaluate.py
@@ -29,7 +29,9 @@ def strategy(monkeypatch: pytest.MonkeyPatch) -> PFPLStrategy:
             handler.close()
 
 
-def test_evaluate_logs_signed_diff(strategy: PFPLStrategy, caplog: pytest.LogCaptureFixture):
+def test_evaluate_logs_signed_diff(
+    strategy: PFPLStrategy, caplog: pytest.LogCaptureFixture
+):
     caplog.set_level(logging.DEBUG, logger="bots.pfpl.strategy")
     caplog.clear()
 

--- a/tests/unit/test_pfpl_evaluate.py
+++ b/tests/unit/test_pfpl_evaluate.py
@@ -2,6 +2,7 @@
 from asyncio import Semaphore
 from decimal import Decimal
 import logging
+from typing import Iterator
 
 import pytest
 
@@ -9,7 +10,7 @@ from bots.pfpl import PFPLStrategy
 
 
 @pytest.fixture
-def strategy(monkeypatch: pytest.MonkeyPatch) -> PFPLStrategy:
+def strategy(monkeypatch: pytest.MonkeyPatch) -> Iterator[PFPLStrategy]:
     monkeypatch.setenv("HL_ACCOUNT_ADDR", "0xTEST")
     monkeypatch.setenv("HL_API_SECRET", "0x" + "11" * 32)
     strat = PFPLStrategy(config={}, semaphore=Semaphore(1))


### PR DESCRIPTION
## Summary
- calculate the signed price delta and percentage inside `PFPLStrategy.evaluate`
- log the signed metrics alongside thresholds, position and order sizing fields
- add a regression test that asserts the debug log shows signed percentages for positive and negative spreads

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d0127d85d48329b206fa648d854d15