### PR TITLE
Fix logger UTC converter binding

### DIFF
--- a/src/hl_core/utils/logger.py
+++ b/src/hl_core/utils/logger.py
@@ -40,6 +40,11 @@ _NOISY_NETWORK_LOGGERS: Final = (
 _LOGGER_CONFIGURED = False
 
 
+def _utc_converter(timestamp: float | None) -> _time.struct_time:
+    ts = 0.0 if timestamp is None else float(timestamp)
+    return _dt.datetime.fromtimestamp(ts, tz=_TZ).timetuple()
+
+
 class _ColorFormatter(logging.Formatter):
     """レベルに応じて色付けして表示するコンソール用フォーマッタ."""
 
@@ -204,11 +209,7 @@ def setup_logger(
     _apply_effective_levels()
 
     # タイムゾーンを UTC に統一
-    def _utc_converter(timestamp: float | None) -> _time.struct_time:
-        ts = 0.0 if timestamp is None else float(timestamp)
-        return _dt.datetime.fromtimestamp(ts, tz=_TZ).timetuple()
-
-    logging.Formatter.converter = _utc_converter  # type: ignore[assignment]
+    logging.Formatter.converter = staticmethod(_utc_converter)  # type: ignore[assignment]
     _LOGGER_CONFIGURED = True
 
 


### PR DESCRIPTION
## Summary
- ensure the logger's UTC converter helper is defined at module scope
- bind the converter using `staticmethod` so `logging.Formatter` does not inject an instance when formatting

## Testing
- python run_bot.py pfpl --symbols "ETH-PERP" --order_usd 1 --log_level INFO

------
https://chatgpt.com/codex/tasks/task_e_68d1172973f4832992cbd77d78ee8fa6