### PR TITLE
Add size allocator parameters to exec config defaults

### DIFF
--- a/configs/strategy.toml
+++ b/configs/strategy.toml
@@ -23,6 +23,11 @@ display_ratio = 0.25       # Iceberg display = total * display_ratio（min/max�
 min_display_btc = 0.01     # Iceberg の最小表示数量
 max_exposure_btc = 0.8     # 総エクスポージャ上限（片側合計）
 cooldown_factor = 2.0      # フィル後の同方向クールダウン時間 = 2×R* 秒
+percent_min = 0.002        # 〔この設定がすること〕 口座残高に対する最小割合（0.2%）
+percent_max = 0.005        # 〔この設定がすること〕 口座残高に対する最大割合（0.5%）
+splits = 1                 # 〔この設定がすること〕 クリップ分割数（>1 で均等割り）
+min_clip_btc = 0.001       # 〔この設定がすること〕 1クリップの最小BTC数量
+equity_usd = 10000.0       # 〔この設定がすること〕 口座残高USD（API未接続時の既定値）
 
 [risk]
 # 〔このセクションがすること〕 ルールベースのリスク管理の閾値

--- a/src/bots/vrlg/config.py
+++ b/src/bots/vrlg/config.py
@@ -117,6 +117,11 @@ class ExecCfg(_BaseConfig):
     min_display_btc: float = 0.01
     max_exposure_btc: float = 0.8
     cooldown_factor: float = 2.0
+    percent_min: float = 0.002     # 〔このフィールドがすること〕 口座残高に対する最小割合（0.2%）
+    percent_max: float = 0.005     # 〔このフィールドがすること〕 口座残高に対する最大割合（0.5%）
+    splits: int = 1                # 〔このフィールドがすること〕 クリップ分割数（>1 で均等割り）
+    min_clip_btc: float = 0.001    # 〔このフィールドがすること〕 1クリップの最小BTC数量
+    equity_usd: float = 10000.0    # 〔このフィールドがすること〕 口座残高USD（API未接続時の既定値）
 
 
 @_decorate
@@ -185,6 +190,11 @@ def coerce_vrlg_config(raw: Any) -> VRLGConfig:
         "min_display_btc": float(sec_exec.get("min_display_btc", 0.01)),
         "max_exposure_btc": float(sec_exec.get("max_exposure_btc", 0.8)),
         "cooldown_factor": float(sec_exec.get("cooldown_factor", 2.0)),
+        "percent_min": float(sec_exec.get("percent_min", 0.002)),
+        "percent_max": float(sec_exec.get("percent_max", 0.005)),
+        "splits": int(sec_exec.get("splits", 1)),
+        "min_clip_btc": float(sec_exec.get("min_clip_btc", 0.001)),
+        "equity_usd": float(sec_exec.get("equity_usd", 10000.0)),
     })
     risk = RiskCfg(**{
         "max_slippage_ticks": float(sec_risk.get("max_slippage_ticks", 1.0)),


### PR DESCRIPTION
## Summary
- extend the VRLG execution config schema with size allocator fields and defaults
- populate the strategy exec section with matching default values to avoid missing keys

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d5c359af74832983985bfc8c783b6c