### PR TITLE
Add integration test covering VRLG strategy flow, expose book impact metric, and wire spread collapse exit

### DIFF
--- a/src/bots/pfpl/strategy.py
+++ b/src/bots/pfpl/strategy.py
@@ -704,3 +704,26 @@ class PFPLStrategy:
         if side.upper() == "BUY":
             return base_px * (1 - self.eps_pct)
         return base_px * (1 + self.eps_pct)
+
+
+def log_order_decision(
+    logger,
+    symbol: str,
+    side: str,
+    qty: float,
+    price: float | None,
+    reason: str,
+    will_send: bool,
+) -> None:
+    """この関数がすること: 発注する/しない の判定結果と理由を1行でログに残す。送るならINFO、送らないならDEBUG。"""
+    level = logging.INFO if will_send else logging.DEBUG
+    logger.log(
+        level,
+        "order_decision symbol=%s side=%s qty=%s price=%s will_send=%s reason=%s",
+        symbol,
+        side,
+        qty,
+        price,
+        will_send,
+        reason,
+    )

--- a/src/bots/vrlg/risk_management.py
+++ b/src/bots/vrlg/risk_management.py
@@ -121,6 +121,15 @@ class RiskManager:
         self._slip_stream.append((time.time(), slip_ticks))
         self._trim_slippage()
 
+    def book_impact_sum_5s(self) -> float:
+        """〔このメソッドがすること〕
+        直近5秒の板消費率（display/TopDepth）の合計を返します（Gauge更新用）。
+        内部のイベントをトリムしてから合計します。
+        """
+
+        self._trim_impacts()
+        return float(sum(x for _, x in self._impact_events))
+
     def register_stopout(self) -> None:
         """〔このメソッドがすること〕
         損切り発生を記録します。10 分内に 3 回で一時停止（10 分）に入ります。

--- a/src/bots/vrlg/strategy.py
+++ b/src/bots/vrlg/strategy.py
@@ -208,6 +208,21 @@ class VRLGStrategy:
             except Exception:
                 logger.debug("exe.register_fill failed (ignored)")
 
+    async def _wait_spread_collapse(self, threshold_ticks: float = 1.0, timeout_s: float = 1.0, poll_s: float = 0.02) -> bool:
+        """〔このメソッドがすること〕
+        一定時間内に「スプレッドが threshold_ticks 以下」に縮小したら True を返します。
+        - self._last_features（100ms特徴）をポーリングして判定します。
+        - タイムアウトまたは停止指示で False を返します。
+        """
+
+        deadline = time.monotonic() + max(0.0, float(timeout_s))
+        while time.monotonic() < deadline and not self._stopping.is_set():
+            snap = self._last_features
+            if snap is not None and float(snap.spread_ticks) <= float(threshold_ticks):
+                return True
+            await asyncio.sleep(float(poll_s))
+        return False
+
     async def _exec_loop(self) -> None:
         """〔このメソッドがすること〕
         シグナルを受けてリスク判定→post-only Iceberg の発注→TTL待ち→IOC解消を実行します。
@@ -230,6 +245,11 @@ class VRLGStrategy:
                 if self._last_features is not None:
                     display = min(clip, max(clip * self.exe.display_ratio, self.exe.min_display))
                     self.risk.register_order_post(display_size=display, top_depth=self._last_features.dob)
+                    # 〔この行がすること〕 直近5秒の板消費率合計をメトリクスに反映します
+                    try:
+                        self.metrics.set_book_impact_5s(self.risk.book_impact_sum_5s())
+                    except Exception:
+                        logger.debug("metrics.set_book_impact_5s failed (ignored)")
 
                 # 〔この行がすること〕 Time-Stop を開始（ms後に IOC で強制クローズ）します
                 time_stop_ms = int(getattr(self.cfg.risk, "time_stop_ms", 1200))
@@ -259,27 +279,46 @@ class VRLGStrategy:
 
                 order_ids = await self.exe.place_two_sided(sig.mid, clip, deepen=adv.deepen_post_only)  # 〔この行がすること〕 リスク助言に応じて「深置き」を切り替える
                 self.metrics.inc_orders_submitted(len(order_ids))  # 〔この行がすること〕 提示した注文（maker）の件数を加算
-                await self.exe.wait_fill_or_ttl(order_ids, timeout_s=self.cfg.exec.order_ttl_ms / 1000)
-                self.metrics.inc_orders_canceled(len(order_ids))  # 〔この行がすること〕 TTL経過でキャンセルした件数を加算（簡易近似）
-                cd = self.exe.cooldown_factor * (self.rot.current_period() or 1.0)
-                self.metrics.set_cooldown(cd)                     # 〔この行がすること〕 現在のクールダウン秒数をGaugeへ
 
-                # 成行禁止でなければ IOC で素早く解消
-                if not adv.forbid_market:
-                    await self.exe.flatten_ioc()
-                    # STOP を先に片付ける
+                async def _cancel_stops_and_timers() -> None:
                     for _sid in stop_ids:
                         await self.exe.cancel_order_safely(_sid)
-                    # Time‑Stop を停止
                     if not ts_task.done():
                         ts_task.cancel()
                         with contextlib.suppress(asyncio.CancelledError):
                             await ts_task
-                    # 自動片付けタスクも停止
                     if not stops_cleanup_task.done():
                         stops_cleanup_task.cancel()
                         with contextlib.suppress(asyncio.CancelledError):
                             await stops_cleanup_task
+
+                # 〔このブロックがすること〕
+                # 「TTL経過」 vs 「スプレッド≤1tick縮小」の先着で処理を分岐します。
+                ttl_s = float(self.cfg.exec.order_ttl_ms) / 1000.0
+
+                if adv.forbid_market:
+                    # 成行は禁止 → 通常通り TTL まで待ってキャンセル（Time‑Stopは別途走る）
+                    await self.exe.wait_fill_or_ttl(order_ids, timeout_s=ttl_s)
+                    canceled_count = len(order_ids)
+                else:
+                    # 早期エグジット候補：スプレッドが 1 tick に縮小したら即クローズ
+                    collapsed = await self._wait_spread_collapse(threshold_ticks=1.0, timeout_s=ttl_s, poll_s=0.02)
+                    if collapsed:
+                        # 先に maker を素早くキャンセルしてから IOC で解消
+                        await self.exe.wait_fill_or_ttl(order_ids, timeout_s=0.0)
+                        canceled_count = len(order_ids)
+                        await self.exe.flatten_ioc()
+                        await _cancel_stops_and_timers()
+                    else:
+                        # 縮小しなかった → TTL まで待って通常解消
+                        await self.exe.wait_fill_or_ttl(order_ids, timeout_s=ttl_s)
+                        canceled_count = len(order_ids)
+                        await self.exe.flatten_ioc()
+                        await _cancel_stops_and_timers()
+
+                self.metrics.inc_orders_canceled(canceled_count)  # 〔この行がすること〕 TTLや早期解消でキャンセルした件数を加算（簡易近似）
+                cd = self.exe.cooldown_factor * (self.rot.current_period() or 1.0)
+                self.metrics.set_cooldown(cd)                     # 〔この行がすること〕 現在のクールダウン秒数をGaugeへ
             except asyncio.CancelledError:
                 break
             except Exception as e:  # pragma: no cover

--- a/tests/integration/test_strategy_flow.py
+++ b/tests/integration/test_strategy_flow.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+import asyncio
+import math
+from typing import Any, List, Tuple
+
+import pytest
+
+# import パス差に対応（src 直下運用/パッケージ運用の両方で動くよう二段構えに）
+try:
+    import bots.vrlg.strategy as strategy_mod
+    from bots.vrlg.strategy import VRLGStrategy
+    from bots.vrlg.data_feed import FeatureSnapshot
+except Exception:  # pragma: no cover - テスト環境差分用
+    import src.bots.vrlg.strategy as strategy_mod  # type: ignore
+    from src.bots.vrlg.strategy import VRLGStrategy  # type: ignore
+    from src.bots.vrlg.data_feed import FeatureSnapshot  # type: ignore
+
+try:
+    from bots.vrlg.execution_engine import ExecutionEngine
+    from bots.vrlg.rotation_detector import RotationDetector
+except Exception:  # pragma: no cover - テスト環境差分用
+    from src.bots.vrlg.execution_engine import ExecutionEngine  # type: ignore
+    from src.bots.vrlg.rotation_detector import RotationDetector  # type: ignore
+
+
+class DummyRot(RotationDetector):
+    """〔このクラスがすること〕
+    周期検出のダミー実装:
+      - is_active() は常に True
+      - current_period() は 2.0s
+      - current_phase(t) は (t % 2.0) / 2.0 を返して境界近傍を再現
+    update() は受け取りだけ行い、内部状態は持ちません。
+    """
+
+    def __init__(self, _cfg) -> None:
+        self._p = 2.0
+
+    def update(self, t: float, dob: float, spr: float) -> None:
+        return
+
+    def is_active(self) -> bool:
+        return True
+
+    def current_period(self) -> float:
+        return self._p
+
+    def current_phase(self, t: float) -> float:
+        return (t % self._p) / self._p
+
+
+class SpyExec(ExecutionEngine):
+    """〔このクラスがすること〕
+    発注を本当に出さず、「どの価格で何件出したか」だけ記録します。
+    flatten_ioc/cancel はNo-opにして、テストの安定性を高めます。
+    """
+
+    def __init__(self, cfg: Any, paper: bool) -> None:
+        super().__init__(cfg, paper)
+        self.prices: List[Tuple[str, float]] = []
+
+    async def _post_only_iceberg(self, side: str, price: float, total: float, display: float, ttl_s: float):
+        self.prices.append((side, float(price)))
+        return f"spy-{side}-{price}"
+
+    async def _cancel_many(self, order_ids: list[str]) -> None:  # pragma: no cover - noop
+        return
+
+    async def flatten_ioc(self) -> None:  # pragma: no cover - noop
+        return
+
+
+def _cfg_dict() -> dict:
+    """〔この関数がすること〕 Strategy が読む生設定（dict）を返します（最小構成）。"""
+
+    return {
+        "symbol": {"name": "BTCUSD-PERP", "tick_size": 0.5},
+        "signal": {"N": 4, "x": 0.25, "y": 2.0, "z": 0.15, "obi_limit": 0.6, "T_roll": 30.0},
+        "exec": {
+            "order_ttl_ms": 200,
+            "display_ratio": 0.25,
+            "min_display_btc": 0.01,
+            "max_exposure_btc": 0.8,
+            "cooldown_factor": 2.0,
+            "percent_min": 0.002,
+            "percent_max": 0.005,
+            "splits": 1,
+            "min_clip_btc": 0.001,
+            "equity_usd": 10000.0,
+        },
+        "risk": {
+            "max_slippage_ticks": 1.0,
+            "max_book_impact": 0.02,
+            "time_stop_ms": 400,
+            "stop_ticks": 3.0,
+        },
+        "latency": {"ingest_ms": 10, "order_rt_ms": 60},
+    }
+
+
+@pytest.mark.asyncio
+async def test_strategy_emits_orders_on_valid_signal(monkeypatch) -> None:
+    """〔このテストがすること〕
+    4 条件を満たす特徴量が投入されたとき、VRLGStrategy が発注（両面）を呼ぶことを確認します。
+    手順:
+      1) load_config をパッチして dict を返すようにする
+      2) Strategy を起動し、Rotation を DummyRot に、Execution を SpyExec に差し替える
+      3) DoB の中央値を作るためにベース値を投入 → その後、境界位相で薄板&広スプのサンプルを投入
+      4) SpyExec に価格が記録されていることを確認
+    """
+
+    # 1) load_config のパッチ
+    cfgd = _cfg_dict()
+    monkeypatch.setattr(strategy_mod, "load_config", lambda path: cfgd)
+
+    # data feed を外部依存なしに待機させるダミーに差し替え
+    async def _idle_run_feeds(_cfg, _queue):
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            pass
+
+    monkeypatch.setattr(strategy_mod, "run_feeds", _idle_run_feeds)
+
+    # 2) Strategy 起動
+    st = VRLGStrategy(config_path="dummy.toml", paper=True, prom_port=None)
+    await st.start()
+
+    # Rotation/Execution を差し替え
+    st.rot = DummyRot(st.cfg)
+    st.exe = SpyExec(st.cfg, paper=True)
+
+    # 3) 特徴量を投入（時刻は 0.1s 刻み）
+    t = 0.5
+    for _ in range(4):
+        snap = FeatureSnapshot(t=t, mid=70000.0, spread_ticks=1.0, dob=1000.0, obi=0.0)
+        await st.q_features.put(snap)
+        t += 0.1
+
+    snap = FeatureSnapshot(t=2.01, mid=70000.0, spread_ticks=2.5, dob=600.0, obi=0.1)
+    await st.q_features.put(snap)
+
+    # 4) 少し待って実行ループに処理させる
+    await asyncio.sleep(0.5)
+
+    # 発注が記録されていること（両面で2件が理想だが、クールダウンや境界条件で 1 件でもOKとする）
+    assert len(st.exe.prices) >= 1, f"発注が呼ばれていません: prices={st.exe.prices}"
+
+    # 価格が tick に丸められていることを簡易に確認（0.5 刻み）
+    for _side, px in st.exe.prices:
+        assert math.isclose(px / 0.5, round(px / 0.5), rel_tol=0, abs_tol=1e-9), f"価格がtick丸めされていません: {px}"
+
+    # 後片付け
+    await st.shutdown()

--- a/tests/unit/test_execution_engine.py
+++ b/tests/unit/test_execution_engine.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import math
+from typing import Any, List, Tuple
+
+import pytest
+
+# 実行環境の import パス差（src 直下 or パッケージ化）に対応
+try:
+    from bots.vrlg.execution_engine import ExecutionEngine
+except Exception:
+    from src.bots.vrlg.execution_engine import ExecutionEngine  # type: ignore
+
+
+class SpyExec(ExecutionEngine):
+    """〔このクラスがすること〕
+    ExecutionEngine を継承し、実際の発注APIを呼ばずに「渡された価格・サイド」を記録します。
+    """
+
+    def __init__(self, cfg: Any, paper: bool) -> None:
+        super().__init__(cfg, paper)
+        self.prices: List[Tuple[str, float]] = []
+
+    async def _post_only_iceberg(
+        self, side: str, price: float, total: float, display: float, ttl_s: float
+    ) -> str | None:
+        """〔このメソッドがすること〕 スパイ用に価格を保存し、ダミー order_id を返します。"""
+        self.prices.append((side, float(price)))
+        return f"spy-{side}-{price}"
+
+    async def _cancel_many(self, order_ids: list[str]) -> None:
+        """〔このメソッドがすること〕 キャンセルは何もしない（テストを速く安全に）。"""
+        return
+
+    async def flatten_ioc(self) -> None:
+        """〔このメソッドがすること〕 IOC クローズは何もしない（プレースホルダ）。"""
+        return
+
+
+def _cfg() -> dict:
+    """〔この関数がすること〕 テスト用の最小コンフィグ（tick=0.5, TTL短め）を返します。"""
+    return {
+        "symbol": {"name": "BTCUSD-PERP", "tick_size": 0.5},
+        "exec": {
+            "order_ttl_ms": 50,
+            "display_ratio": 0.25,
+            "min_display_btc": 0.01,
+            "max_exposure_btc": 0.8,
+            "cooldown_factor": 2.0,
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_place_two_sided_offsets_and_rounding() -> None:
+    """〔このテストがすること〕
+    通常（±0.5tick）と深置き（±1.5tick）で、SELL−BUY の価格差が 0.5 / 1.5 になることを検証します。
+    """
+    eng = SpyExec(_cfg(), paper=True)
+    mid = 70000.25  # 0.5tick 丸めの性質が分かりやすいミッド
+
+    # 通常: ±0.5tick → 価格差は 1 tick = 0.5
+    eng.prices.clear()
+    ids = await eng.place_two_sided(mid=mid, total=0.05, deepen=False)
+    assert len(ids) == 2, "通常置きで両面の発注が出ていません"
+    prices = dict(eng.prices)  # {"BUY": px_bid, "SELL": px_ask}
+    diff_normal = prices["SELL"] - prices["BUY"]
+    assert math.isclose(diff_normal, 0.5, rel_tol=0, abs_tol=1e-9), f"通常置きのスプレッド期待=0.5, got={diff_normal}"
+
+    # 深置き: ±1.5tick → 価格差は 3 tick = 1.5
+    eng.prices.clear()
+    ids = await eng.place_two_sided(mid=mid, total=0.05, deepen=True)
+    assert len(ids) == 2, "深置きで両面の発注が出ていません"
+    prices = dict(eng.prices)
+    diff_deep = prices["SELL"] - prices["BUY"]
+    assert math.isclose(diff_deep, 1.5, rel_tol=0, abs_tol=1e-9), f"深置きのスプレッド期待=1.5, got={diff_deep}"
+
+
+@pytest.mark.asyncio
+async def test_cooldown_skips_same_side() -> None:
+    """〔このテストがすること〕 register_fill() 後は同方向の発注がクールダウンでスキップされることを確認します。"""
+    eng = SpyExec(_cfg(), paper=True)
+    mid = 70000.25
+
+    # 直前のフィルを BUY と記録 → 直後の place_two_sided では BUY がスキップされ SELL のみ出る想定
+    eng.register_fill("BUY")
+    ids = await eng.place_two_sided(mid=mid, total=0.05, deepen=False)
+    # BUY がスキップされ SELL のみ=1件になるはず
+    assert len(ids) == 1, f"クールダウンで同方向をスキップできていません（ids={ids})"


### PR DESCRIPTION
## Summary
- add an integration test that boots VRLGStrategy with dummy rotation and spy execution components
- feed synthetic features through the queues to verify the signal gate triggers order placement
- ensure order prices are tick-rounded and recorded without hitting external adapters
- make the DummyRot test double inherit from RotationDetector so type checkers accept it
- expose the risk manager's 5-second book impact sum so metrics can publish it
- update the strategy loop to refresh the book impact gauge after registering order display sizes
- race order TTL against a spread-collapse watcher so we flatten early with IOC when markets tighten and maker quotes are still live

## Testing
- poetry run pytest tests/integration/test_strategy_flow.py
- poetry run pyright


------
https://chatgpt.com/codex/tasks/task_e_68d5d8eb6988832994ebf923f76df9a4