### PR TITLE
Add structured decision logging for VRLG strategy

### DIFF
--- a/src/bots/vrlg/decision_log.py
+++ b/src/bots/vrlg/decision_log.py
@@ -1,0 +1,45 @@
+# 〔このモジュールがすること〕
+# VRLG の意思決定イベントを「1行JSON」で記録します（リングバッファ + 任意でファイル書き出し）。
+# ログ項目例: signal/order_intent/order_submitted/exit/risk_pause/fill/block_interval など。
+
+from __future__ import annotations
+
+import json
+import time
+from collections import deque
+from typing import Any, Deque, Dict, List, Optional
+
+from hl_core.utils.logger import get_logger
+
+logger = get_logger("VRLG.decisions")
+
+
+class DecisionLogger:
+    """〔このクラスがすること〕
+    意思決定イベントをリングバッファに蓄え、必要なら JSONL ファイルへ追記します。
+    """
+
+    def __init__(self, maxlen: int = 10000, filepath: Optional[str] = None) -> None:
+        """〔このメソッドがすること〕 バッファ長と出力先（任意）を設定します。"""
+        self._buf: Deque[Dict[str, Any]] = deque(maxlen=maxlen)
+        self._path: Optional[str] = filepath
+
+    def log(self, event: str, **fields: Any) -> None:
+        """〔このメソッドがすること〕
+        任意のキー/値を受け取り、{t,event,...} 形式で記録します。ファイル指定があれば追記します。
+        """
+        rec: Dict[str, Any] = {"t": time.time(), "event": str(event)}
+        rec.update(fields)
+        self._buf.append(rec)
+        if self._path:
+            try:
+                with open(self._path, "a", encoding="utf-8") as f:
+                    f.write(json.dumps(rec, ensure_ascii=False) + "\n")
+            except Exception as e:  # pragma: no cover
+                logger.debug("decision log write failed: %s", e)
+
+    def latest(self, n: int = 100) -> List[Dict[str, Any]]:
+        """〔このメソッドがすること〕 直近 n 件の記録を返します（デバッグ用）。"""
+        if n <= 0:
+            return []
+        return list(self._buf)[-n:]


### PR DESCRIPTION
## Summary
- add a reusable DecisionLogger that buffers events and optionally appends to JSONL files
- wire the logger into VRLGStrategy to record signals, risk pauses, order lifecycle, fills, and block intervals
- expose a --decisions-file CLI option so operators can persist structured decision logs
- honor the CLI --log-level option by updating the VRLG logger configuration at startup

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d6b272b2648329b1ea01ba4de8a097