### PR TITLE
Track VRLG maker exposure to enforce max_exposure

### DIFF
--- a/src/bots/vrlg/decision_log.py
+++ b/src/bots/vrlg/decision_log.py
@@ -1,0 +1,45 @@
+# 〔このモジュールがすること〕
+# VRLG の意思決定イベントを「1行JSON」で記録します（リングバッファ + 任意でファイル書き出し）。
+# ログ項目例: signal/order_intent/order_submitted/exit/risk_pause/fill/block_interval など。
+
+from __future__ import annotations
+
+import json
+import time
+from collections import deque
+from typing import Any, Deque, Dict, List, Optional
+
+from hl_core.utils.logger import get_logger
+
+logger = get_logger("VRLG.decisions")
+
+
+class DecisionLogger:
+    """〔このクラスがすること〕
+    意思決定イベントをリングバッファに蓄え、必要なら JSONL ファイルへ追記します。
+    """
+
+    def __init__(self, maxlen: int = 10000, filepath: Optional[str] = None) -> None:
+        """〔このメソッドがすること〕 バッファ長と出力先（任意）を設定します。"""
+        self._buf: Deque[Dict[str, Any]] = deque(maxlen=maxlen)
+        self._path: Optional[str] = filepath
+
+    def log(self, event: str, **fields: Any) -> None:
+        """〔このメソッドがすること〕
+        任意のキー/値を受け取り、{t,event,...} 形式で記録します。ファイル指定があれば追記します。
+        """
+        rec: Dict[str, Any] = {"t": time.time(), "event": str(event)}
+        rec.update(fields)
+        self._buf.append(rec)
+        if self._path:
+            try:
+                with open(self._path, "a", encoding="utf-8") as f:
+                    f.write(json.dumps(rec, ensure_ascii=False) + "\n")
+            except Exception as e:  # pragma: no cover
+                logger.debug("decision log write failed: %s", e)
+
+    def latest(self, n: int = 100) -> List[Dict[str, Any]]:
+        """〔このメソッドがすること〕 直近 n 件の記録を返します（デバッグ用）。"""
+        if n <= 0:
+            return []
+        return list(self._buf)[-n:]

--- a/src/bots/vrlg/execution_engine.py
+++ b/src/bots/vrlg/execution_engine.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import asyncio
 import time
-from typing import Optional
+from typing import Optional, Callable, Dict, Any  # 〔この行がすること〕 オーダーイベント用のコールバック型を使えるようにする
 
 from hl_core.utils.logger import get_logger
 
@@ -59,6 +59,9 @@ class ExecutionEngine:
         self._last_fill_side: Optional[str] = None  # "BUY" or "SELL"
         self._last_fill_time: float = 0.0
         self._period_s: float = 1.0  # RotationDetector から更新注入予定
+        self.on_order_event: Optional[Callable[[str, Dict[str, Any]], None]] = None  # 〔この行がすること〕 'skip'/'submitted'/'reject'/'cancel' を Strategy 側へ通知するコールバック
+        self._open_maker_btc: float = 0.0  # 〔この属性がすること〕 未キャンセルの maker 注文サイズ合計（BTC）を管理
+        self._order_size: Dict[str, float] = {}  # 〔この属性がすること〕 order_id → 発注 total サイズの対応
 
     def set_period_hint(self, period_s: float) -> None:
         """〔このメソッドがすること〕 R*（推定周期）ヒントを注入し、クールダウン計算に使います。"""
@@ -79,12 +82,71 @@ class ExecutionEngine:
 
         ids: list[str] = []
         for side, price in (("BUY", px_bid), ("SELL", px_ask)):
+            # 〔このブロックがすること〕 上限を超えるならその片側はスキップ（意思決定ログへ通知）
+            if (self._open_maker_btc + total) > self.max_exposure:
+                try:
+                    if self.on_order_event:
+                        self.on_order_event(
+                            "skip",
+                            {
+                                "side": side,
+                                "reason": "exposure",
+                                "open_maker_btc": float(self._open_maker_btc),
+                            },
+                        )
+                except Exception:
+                    pass
+                continue
             if self._in_cooldown(side):
                 logger.debug("cooldown active: skip %s", side)
+                # 〔このブロックがすること〕 クールダウンによるスキップを上位へ通知（意思決定ログ用）
+                try:
+                    if self.on_order_event:
+                        self.on_order_event(
+                            "skip",
+                            {
+                                "side": side,
+                                "reason": "cooldown",
+                                "open_maker_btc": float(self._open_maker_btc),
+                            },
+                        )
+                except Exception:
+                    pass
                 continue
             oid = await self._post_only_iceberg(side, price, total, display, self.ttl_ms / 1000.0)
             if oid:
+                # 〔この行がすること〕 受理された maker 注文の露出を加算し、order_id を記録
+                self._open_maker_btc += float(total)
+                self._order_size[str(oid)] = float(total)
+                # 〔このブロックがすること〕 発注が通った事実を通知（片側ごと）
+                try:
+                    if self.on_order_event:
+                        self.on_order_event(
+                            "submitted",
+                            {
+                                "side": side,
+                                "price": float(price),
+                                "order_id": str(oid),
+                                "open_maker_btc": float(self._open_maker_btc),
+                            },
+                        )
+                except Exception:
+                    pass
                 ids.append(oid)
+            else:
+                # 〔このブロックがすること〕 取引所から拒否/未受理（None）を通知
+                try:
+                    if self.on_order_event:
+                        self.on_order_event(
+                            "reject",
+                            {
+                                "side": side,
+                                "price": float(price),
+                                "open_maker_btc": float(self._open_maker_btc),
+                            },
+                        )
+                except Exception:
+                    pass
         return ids
 
     async def wait_fill_or_ttl(self, order_ids: list[str], timeout_s: float) -> None:
@@ -98,6 +160,22 @@ class ExecutionEngine:
             await asyncio.sleep(timeout_s)
         finally:
             await self._cancel_many(order_ids)
+            # 〔このブロックがすること〕 キャンセル完了後に、未約定メーカー露出を減算
+            for _oid in order_ids:
+                self._reduce_open_maker(_oid)
+            # 〔このブロックがすること〕 TTL/解消でキャンセルした事実を片側ごとに通知（露出も併記）
+            try:
+                if self.on_order_event:
+                    for _oid in order_ids:
+                        self.on_order_event(
+                            "cancel",
+                            {
+                                "order_id": str(_oid),
+                                "open_maker_btc": float(self._open_maker_btc),
+                            },
+                        )
+            except Exception:
+                pass
 
     async def flatten_ioc(self) -> None:
         """〔このメソッドがすること〕 市場成行（IOC）で素早くフラット化します（スケルトン）。"""
@@ -159,6 +237,17 @@ class ExecutionEngine:
             return
         try:
             await cancel_order(self.symbol, order_id)  # type: ignore[misc]
+            # 〔この行がすること〕 手動キャンセルでも露出を減算
+            self._reduce_open_maker(order_id)
+            # 〔このブロックがすること〕 手動キャンセルの通知（露出も併記）
+            try:
+                if self.on_order_event:
+                    self.on_order_event(
+                        "cancel",
+                        {"order_id": str(order_id), "open_maker_btc": float(self._open_maker_btc)},
+                    )
+            except Exception:
+                pass
         except Exception as e:
             logger.debug("cancel_order (safe) ignored: %s", e)
 
@@ -220,6 +309,18 @@ class ExecutionEngine:
                 await cancel_order(self.symbol, oid)  # type: ignore[misc]
             except Exception as e:
                 logger.debug("cancel_order failed (ignored): %s", e)
+
+    def _reduce_open_maker(self, order_id: str) -> None:
+        """〔このメソッドがすること〕
+        指定 order_id の発注サイズを台帳から引き当て、未約定メーカー露出を減算します。
+        （同じ order_id に対しては一度だけ作用）
+        """
+        try:
+            size = float(self._order_size.pop(order_id, 0.0))
+        except Exception:
+            size = 0.0
+        if size > 0.0:
+            self._open_maker_btc = max(0.0, self._open_maker_btc - size)
 
     # ─────────────── クールダウン管理（簡易） ───────────────
 

--- a/src/bots/vrlg/metrics.py
+++ b/src/bots/vrlg/metrics.py
@@ -66,6 +66,7 @@ class Metrics:
         self.active_flag = Gauge("vrlg_is_active", "Rotation gate active (1) or paused (0).")
         self.book_impact_5s = Gauge("vrlg_book_impact_5s", "Sum of display/TopDepth over 5s.")
         self.cooldown_s = Gauge("vrlg_cooldown_s", "Current cooldown window (s).")
+        self.open_maker_btc = Gauge("vrlg_open_maker_btc", "Open maker exposure (BTC).")  # 〔この行がすること〕 未約定メーカー合計BTCを可視化
 
         # ── Histograms（分布）
         self.spread_ticks = Histogram(
@@ -190,5 +191,12 @@ class Metrics:
         """〔この関数がすること〕 現在のクールダウン秒数を Gauge に設定します。"""
         try:
             self.cooldown_s.set(max(0.0, float(seconds)))
+        except Exception:
+            pass
+
+    def set_open_maker_btc(self, value: float) -> None:
+        """〔この関数がすること〕 未約定メーカー合計BTCを Gauge に設定します。"""
+        try:
+            self.open_maker_btc.set(max(0.0, float(value)))
         except Exception:
             pass

--- a/src/bots/vrlg/strategy.py
+++ b/src/bots/vrlg/strategy.py
@@ -33,6 +33,7 @@ from .signal_detector import SignalDetector
 from .execution_engine import ExecutionEngine
 from .risk_management import RiskManager
 from .metrics import Metrics  # 〔この import がすること〕 Prometheus 送信ラッパを使えるようにする
+from .decision_log import DecisionLogger  # 〔この import がすること〕 意思決定のJSONログを使えるようにする
 from .size_allocator import SizeAllocator  # 〔この import がすること〕 口座割合ベースのサイズ決定を使えるようにする
 
 logger = get_logger("VRLG")
@@ -47,7 +48,7 @@ class VRLGStrategy:
     - 将来、Prometheus のメトリクス公開を行う
     """
 
-    def __init__(self, config_path: str, paper: bool, prom_port: Optional[int] = None) -> None:  # 〔この行がすること〕 --prom-port を受け取り Metrics を起動できるようにする
+    def __init__(self, config_path: str, paper: bool, prom_port: Optional[int] = None, decisions_file: Optional[str] = None) -> None:  # 〔この行がすること〕 意思決定ログの出力先を受け取れるようにする
         """〔このメソッドがすること〕
         TOML/YAML 設定を読み込み、実行モード（paper/live）を保持します。
         """
@@ -64,6 +65,7 @@ class VRLGStrategy:
         self.q_features: asyncio.Queue = asyncio.Queue(maxsize=1024)
         self.q_signals: asyncio.Queue = asyncio.Queue(maxsize=1024)
         self.metrics = Metrics(port=prom_port)  # 〔この行がすること〕 /metrics を起動し、以降の観測値を送れるようにする
+        self.decisions = DecisionLogger(filepath=decisions_file)  # 〔この行がすること〕 意思決定ログの出力を初期化
 
         # 〔この属性がすること〕直近の特徴量を保持し、発注時に板消費率などの参照に使います。
         self._last_features: Optional[FeatureSnapshot] = None
@@ -72,6 +74,8 @@ class VRLGStrategy:
         self.rot = RotationDetector(self.cfg)
         self.sigdet = SignalDetector(self.cfg)
         self.exe = ExecutionEngine(self.cfg, paper=self.paper)
+        # 〔この行がすること〕 発注イベント（skip/submitted/reject/cancel）を Strategy で受け取れるよう接続
+        self.exe.on_order_event = self._on_order_event
         self.risk = RiskManager(self.cfg)
         self.sizer = SizeAllocator(self.cfg)  # 〔この行がすること〕 0.2–0.5% 基準のサイズ決定器を用意
 
@@ -113,6 +117,7 @@ class VRLGStrategy:
                 self.exe.set_period_hint(self.rot.current_period() or 1.0)
                 sig = self.sigdet.update_and_maybe_signal(feat.t, feat.with_phase(phase))
                 if sig:
+                    self.decisions.log("signal", phase=phase, spread_ticks=float(feat.spread_ticks), dob=float(feat.dob), obi=float(feat.obi))  # 〔この行がすること〕 シグナルの根拠となる特徴量を記録
                     self.metrics.inc_signal()  # 〔この行がすること〕 シグナル発火回数をカウントアップ
                     await self.q_signals.put(sig)
             except asyncio.CancelledError:
@@ -154,7 +159,35 @@ class VRLGStrategy:
                     self.metrics.observe_block_interval_ms(interval)   # Prometheus へ記録
                 except Exception:
                     logger.debug("metrics.observe_block_interval_ms failed (ignored)")
+                self.decisions.log("block_interval", interval_s=float(interval))  # 〔この行がすること〕 観測したブロック間隔を記録
             last_ts = blk_ts
+
+    def _on_order_event(self, kind: str, fields: dict) -> None:
+        """〔この関数がすること〕
+        ExecutionEngine からのオーダーイベントを受け取り、意思決定ログとメトリクスへ反映します。
+        kind: 'skip' | 'submitted' | 'reject' | 'cancel'
+        """
+        # 1) 意思決定ログへ（order_skip / order_submitted / order_reject / order_cancel のイベント名で統一）
+        try:
+            self.decisions.log(f"order_{kind}", **fields)
+        except Exception:
+            pass
+
+        # 2) メトリクスへ（submitted は既に別で集計しているため二重加算を避ける）
+        try:
+            if kind == "reject":
+                self.metrics.inc_orders_rejected(1)
+            elif kind == "cancel":
+                self.metrics.inc_orders_canceled(1)
+        except Exception:
+            pass
+
+        # 〔このブロックがすること〕 open_maker_btc が含まれていれば Gauge を更新
+        try:
+            if "open_maker_btc" in fields:
+                self.metrics.set_open_maker_btc(float(fields["open_maker_btc"]))
+        except Exception:
+            pass
 
     async def _fills_loop(self) -> None:
         """〔このメソッドがすること〕
@@ -199,6 +232,7 @@ class VRLGStrategy:
                 slip_ticks = abs(price - ref_mid) / max(tick, 1e-12)
                 self.metrics.observe_slippage(slip_ticks)
                 self.metrics.inc_fills(1)
+                self.decisions.log("fill", side=side, price=float(price), ref_mid=float(ref_mid), slip_ticks=float(slip_ticks))  # 〔この行がすること〕 約定と滑りを記録
             except Exception:
                 logger.debug("metrics(slippage/fills) failed (ignored)")
 
@@ -234,12 +268,14 @@ class VRLGStrategy:
                 # リスク助言（キル/一時停止/サイズ倍率/成行禁止など）
                 adv = self.risk.advice()
                 if self.risk.should_pause() or adv.killswitch:
+                    self.decisions.log("risk_pause", killswitch=bool(adv.killswitch), paused_until=adv.paused_until, reason=str(adv.reason))  # 〔この行がすること〕 リスク由来の停止理由を記録
                     if adv.killswitch:
                         await self.exe.flatten_ioc()  # 念のため即フラット
                     continue
 
                 # 〔この行がすること〕 口座残高の0.2–0.5%を基準に、リスク倍率を反映して1クリップのBTCサイズを決める
                 clip = self.sizer.next_size(mid=sig.mid, risk_mult=adv.size_multiplier)
+                self.decisions.log("order_intent", mid=float(sig.mid), clip=float(clip), deepen=bool(adv.deepen_post_only))  # 〔この行がすること〕 置くサイズと深さの意図を記録
 
                 # 板消費率トラッキングのため display を事前計算（Feature の DoB 使用）
                 if self._last_features is not None:
@@ -278,6 +314,7 @@ class VRLGStrategy:
                 stops_cleanup_task = asyncio.create_task(_cleanup_stops_after_ts(), name="stops_cleanup")
 
                 order_ids = await self.exe.place_two_sided(sig.mid, clip, deepen=adv.deepen_post_only)  # 〔この行がすること〕 リスク助言に応じて「深置き」を切り替える
+                self.decisions.log("order_submitted", count=int(len(order_ids)))  # 〔この行がすること〕 実際に何件出したかを記録
                 self.metrics.inc_orders_submitted(len(order_ids))  # 〔この行がすること〕 提示した注文（maker）の件数を加算
 
                 async def _cancel_stops_and_timers() -> None:
@@ -297,9 +334,10 @@ class VRLGStrategy:
                 ttl_s = float(self.cfg.exec.order_ttl_ms) / 1000.0
 
                 if adv.forbid_market:
+                    self.decisions.log("exit_policy", policy="forbid_market")  # 〔この行がすること〕 早期IOCを行わない方針であることを記録
                     # 成行は禁止 → 通常通り TTL まで待ってキャンセル（Time‑Stopは別途走る）
                     await self.exe.wait_fill_or_ttl(order_ids, timeout_s=ttl_s)
-                    canceled_count = len(order_ids)
+                    self.decisions.log("exit", reason="ttl")  # 〔この行がすること〕 TTL 到達で通常解消したことを記録
                 else:
                     # 早期エグジット候補：スプレッドが 1 tick に縮小したら即クローズ
                     # 〔この行がすること〕 しきい値を設定から受け取り、縮小判定に使う
@@ -310,19 +348,18 @@ class VRLGStrategy:
                     )
 
                     if collapsed:
+                        self.decisions.log("exit", reason="spread_collapse")  # 〔この行がすること〕 スプレッド縮小で早期IOCしたことを記録
                         # 先に maker を素早くキャンセルしてから IOC で解消
                         await self.exe.wait_fill_or_ttl(order_ids, timeout_s=0.0)
-                        canceled_count = len(order_ids)
                         await self.exe.flatten_ioc()
                         await _cancel_stops_and_timers()
                     else:
+                        self.decisions.log("exit", reason="ttl")  # 〔この行がすること〕 TTL 到達で通常解消したことを記録
                         # 縮小しなかった → TTL まで待って通常解消
                         await self.exe.wait_fill_or_ttl(order_ids, timeout_s=ttl_s)
-                        canceled_count = len(order_ids)
                         await self.exe.flatten_ioc()
                         await _cancel_stops_and_timers()
 
-                self.metrics.inc_orders_canceled(canceled_count)  # 〔この行がすること〕 TTLや早期解消でキャンセルした件数を加算（簡易近似）
                 cd = self.exe.cooldown_factor * (self.rot.current_period() or 1.0)
                 self.metrics.set_cooldown(cd)                     # 〔この行がすること〕 現在のクールダウン秒数をGaugeへ
             except asyncio.CancelledError:
@@ -357,6 +394,7 @@ def parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
     g.add_argument("--live", action="store_true", help="live trading mode")
     p.add_argument("--log-level", default="INFO", help="logging level")
     p.add_argument("--prom-port", type=int, default=None, help="Prometheus metrics port (optional)")  # 〔この行がすること〕 /metrics を公開するポート番号の受け取り
+    p.add_argument("--decisions-file", default=None, help="path to JSONL file for decision logs (optional)")  # 〔この行がすること〕 意思決定ログの保存先を受け取る
     return p.parse_args(argv)
 
 
@@ -365,9 +403,14 @@ async def _run(argv: list[str]) -> int:
     uvloop を可能なら有効化し、VRLGStrategy を起動してシグナルで停止します。
     """
     args = parse_args(argv)
+    # 〔この行がすること〕 CLI の --log-level を VRLG ロガーへ反映する
+    try:
+        logger.setLevel(str(args.log_level).upper())
+    except Exception:
+        pass
     if uvloop is not None:
         uvloop.install()
-    strategy = VRLGStrategy(config_path=args.config, paper=not args.live, prom_port=args.prom_port)  # 〔この行がすること〕 --prom-port を Strategy へ受け渡す
+    strategy = VRLGStrategy(config_path=args.config, paper=not args.live, prom_port=args.prom_port, decisions_file=args.decisions_file)  # 〔この行がすること〕 CLI からロガーへ出力先を渡す
     await strategy.start()
 
     loop = asyncio.get_running_loop()


### PR DESCRIPTION
## Summary
- add a reusable DecisionLogger that buffers events and optionally appends to JSONL files
- wire the logger into VRLGStrategy to record signals, risk pauses, order lifecycle, fills, and block intervals
- expose a --decisions-file CLI option so operators can persist structured decision logs
- honor the CLI --log-level option by updating the VRLG logger configuration at startup
- surface execution-engine skip/submitted/reject/cancel events through callbacks so decision logs and metrics capture skipped or rejected orders
- track open maker exposure in the execution engine so new orders are skipped when they would exceed max_exposure, and decrement exposure when cancellations finish
- expose open maker exposure as a Prometheus gauge so dashboards reflect TTL- and cancel-driven adjustments in real time

## Testing
- poetry run ruff check .

------
https://chatgpt.com/codex/tasks/task_e_68d6b272b2648329b1ea01ba4de8a097