### PR TITLE
Add side mode support for VRLG execution engine

### DIFF
--- a/configs/strategy.toml
+++ b/configs/strategy.toml
@@ -31,6 +31,7 @@ equity_usd = 10000.0       # 〔この設定がすること〕 口座残高USD�
 offset_ticks_normal = 0.5     # 〔この設定がすること〕 通常置きの価格オフセット（±tick）
 offset_ticks_deep   = 1.5     # 〔この設定がすること〕 深置きの価格オフセット（±tick）
 spread_collapse_ticks = 1.0   # 〔この設定がすること〕 早期IOCの縮小判定のしきい値（tick）
+side_mode = "both"        # 〔この設定がすること〕 発注の向き: "both" | "buy" | "sell"
 
 [risk]
 # 〔このセクションがすること〕 ルールベースのリスク管理の閾値

--- a/src/bots/vrlg/config.py
+++ b/src/bots/vrlg/config.py
@@ -117,6 +117,7 @@ class ExecCfg(_BaseConfig):
     min_display_btc: float = 0.01
     max_exposure_btc: float = 0.8
     cooldown_factor: float = 2.0
+    side_mode: str = "both"        # 〔このフィールドがすること〕 発注の向き: "both" | "buy" | "sell"
     offset_ticks_normal: float = 0.5   # 〔このフィールドがすること〕 通常置きの価格オフセット（±tick）
     offset_ticks_deep: float = 1.5     # 〔このフィールドがすること〕 深置きの価格オフセット（±tick）
     spread_collapse_ticks: float = 1.0 # 〔このフィールドがすること〕 早期IOCの縮小判定のしきい値（tick）
@@ -193,6 +194,7 @@ def coerce_vrlg_config(raw: Any) -> VRLGConfig:
         "min_display_btc": float(sec_exec.get("min_display_btc", 0.01)),
         "max_exposure_btc": float(sec_exec.get("max_exposure_btc", 0.8)),
         "cooldown_factor": float(sec_exec.get("cooldown_factor", 2.0)),
+        "side_mode": str(sec_exec.get("side_mode", "both")),
         "offset_ticks_normal": float(sec_exec.get("offset_ticks_normal", 0.5)),
         "offset_ticks_deep": float(sec_exec.get("offset_ticks_deep", 1.5)),
         "spread_collapse_ticks": float(sec_exec.get("spread_collapse_ticks", 1.0)),


### PR DESCRIPTION
## Summary
- add the `side_mode` execution configuration option and default strategy value
- load the new option in the VRLG config coercion utilities
- honor the configured side mode when submitting iceberg orders in the execution engine

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7ff4a68ec83299c00ad861e5c4d11