### PR TITLE
Refine VRLG book impact accounting

### DIFF
--- a/src/bots/vrlg/strategy.py
+++ b/src/bots/vrlg/strategy.py
@@ -385,16 +385,6 @@ class VRLGStrategy:
                     trace_id=getattr(sig, "trace_id", None),
                 )  # 〔この行がすること〕 置くサイズと深さの意図を記録
 
-                # 板消費率トラッキングのため display を事前計算（Feature の DoB 使用）
-                if self._last_features is not None:
-                    display = min(clip, max(clip * self.exe.display_ratio, self.exe.min_display))
-                    self.risk.register_order_post(display_size=display, top_depth=self._last_features.dob)
-                    # 〔この行がすること〕 直近5秒の板消費率合計をメトリクスに反映します
-                    try:
-                        self.metrics.set_book_impact_5s(self.risk.book_impact_sum_5s())
-                    except Exception:
-                        logger.debug("metrics.set_book_impact_5s failed (ignored)")
-
                 # 〔この行がすること〕 Time-Stop を開始（ms後に IOC で強制クローズ）します
                 time_stop_ms = int(getattr(self.cfg.risk, "time_stop_ms", 1200))
                 ts_task = asyncio.create_task(self.exe.time_stop_after(time_stop_ms), name="time_stop")


### PR DESCRIPTION
## Summary
- remove the pre-submission risk accounting in the exec loop so submitted events own the bookkeeping
- confirmed the submitted event handler still updates the book_impact_5s gauge after registering order impact

## Testing
- poetry run ruff check src/bots/vrlg/strategy.py

------
https://chatgpt.com/codex/tasks/task_e_68d9aa0d2fcc8329801169b9f642e843