### PR TITLE
Ensure run_bot.py re-executes via project venv

### DIFF
--- a/run_bot.py
+++ b/run_bot.py
@@ -25,6 +25,7 @@ def ensure_project_venv():
 
 ensure_project_venv()
 
+# ruff: noqa: E402  # runtime venv enforcement requires imports below
 import argparse
 import asyncio
 import logging


### PR DESCRIPTION
## Summary
- ensure `run_bot.py` restarts itself under the project-local `.venv` interpreter before importing other modules

## Testing
- `PYTHONPATH=src python run_bot.py foo --dry-run --testnet` *(fails: ModuleNotFoundError: No module named 'hyperliquid.info' due to missing dependency in the temporary venv)*

------
https://chatgpt.com/codex/tasks/task_e_68dabf2d64848329a7137afc270752ad