### PR TITLE
Improve VRLG feed resilience with automatic fallback

### DIFF
--- a/backtest/sweep_vrlg.py
+++ b/backtest/sweep_vrlg.py
@@ -1,0 +1,198 @@
+# 〔このスクリプトがすること〕
+# VRLG の主要ハイパラ（signal.x, signal.y, exec.order_ttl_ms）を
+# グリッドまたは Optuna でスイープし、backtest/VRLGSimulator で評価します。
+# 目的関数（近似）: score = Sharpe_per_trade − 0.5 × (MaxDD_bps / 10)
+# ※ Optuna が無い環境でもグリッドサーチで動きます（必須依存なし）。
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Tuple
+
+# 〔この import がすること〕 VRLG のバックテスト基盤を再利用します
+try:
+    from backtest.vrlg_sim import VRLGSimulator, load_level2_stream  # type: ignore
+except Exception:
+    from .vrlg_sim import VRLGSimulator, load_level2_stream  # type: ignore
+
+
+def _load_config(path: str) -> Dict[str, Any]:
+    """〔この関数がすること〕 設定ファイル（TOML/YAML）を読み込み dict を返します。"""
+    try:
+        from hl_core.utils.config import load_config  # type: ignore
+        return load_config(path)  # type: ignore[return-value]
+    except Exception:
+        pass
+    # TOML フォールバック（Python 3.11+）
+    try:
+        import tomllib  # type: ignore
+        with open(path, "rb") as f:
+            return tomllib.load(f)
+    except Exception:
+        import tomli  # type: ignore
+        with open(path, "rb") as f:
+            return tomli.load(f)
+
+
+def _deepcopy_cfg(cfg: Dict[str, Any]) -> Dict[str, Any]:
+    """〔この関数がすること〕 設定 dict をディープコピーします（試行ごとに安全に改変するため）。"""
+    return json.loads(json.dumps(cfg))
+
+
+def _apply_params(cfg: Dict[str, Any], x: float, y: float, ttl_s: float) -> Dict[str, Any]:
+    """〔この関数がすること〕 ハイパラ (x, y, ttl_s) を設定 dict に反映して返します。"""
+    c = _deepcopy_cfg(cfg)
+    c.setdefault("signal", {})
+    c.setdefault("exec", {})
+    c["signal"]["x"] = float(x)
+    c["signal"]["y"] = float(y)
+    c["exec"]["order_ttl_ms"] = int(round(ttl_s * 1000.0))
+    return c
+
+
+def _sharpe_per_trade(pnl_bps: List[float]) -> float:
+    """〔この関数がすること〕 取引ごとの bps リターンから簡易 Sharpe（√N スケーリング）を返します。"""
+    n = len(pnl_bps)
+    if n == 0:
+        return 0.0
+    mu = sum(pnl_bps) / n
+    var = sum((x - mu) ** 2 for x in pnl_bps) / max(1, n - 1)
+    sd = math.sqrt(max(0.0, var))
+    if sd == 0:
+        return float("inf") if mu > 0 else 0.0
+    return (mu / sd) * math.sqrt(n)
+
+
+def _objective_from_summary(s: Dict[str, Any]) -> float:
+    """〔この関数がすること〕 VRLGSimulator.summary() から目的関数値を計算します。"""
+    n = int(s.get("trades", 0))
+    if n == 0:
+        return -1e9
+    sharpe = _sharpe_per_trade([s.get("avg_pnl_bps", 0.0)])  # 近似（集計のみ保持時の保険）
+    # 可能なら全トレード平均/分散で厳密化：summary() が将来トレード配列を返すなら差し替え
+    sharpe = float(s.get("avg_pnl_bps", 0.0)) / max(1e-9, s.get("median_pnl_bps", 1.0)) if sharpe == 0 else sharpe
+    dd_pen = 0.5 * float(s.get("max_drawdown_bps", 0.0)) / 10.0
+    return sharpe - dd_pen
+
+
+def _evaluate(cfg: Dict[str, Any], data: List[Tuple[float, float, float, float, float]]) -> Tuple[float, Dict[str, Any]]:
+    """〔この関数がすること〕 1 組の設定でシミュレータを実行し、(score, summary) を返します。"""
+    sim = VRLGSimulator(cfg)
+    sim.run(iter(data))
+    s = sim.summary()
+    return _objective_from_summary(s), s
+
+
+def _grid(params_x: Iterable[float], params_y: Iterable[float], params_ttl: Iterable[float]) -> List[Tuple[float, float, float]]:
+    """〔この関数がすること〕 グリッド（x × y × ttl）を列挙して返します。"""
+    combos = []
+    for x in params_x:
+        for y in params_y:
+            for t in params_ttl:
+                combos.append((float(x), float(y), float(t)))
+    return combos
+
+
+def parse_args() -> argparse.Namespace:
+    """〔この関数がすること〕 CLI 引数を解釈します。"""
+    p = argparse.ArgumentParser(description="VRLG hyperparameter sweep (grid / optuna)")
+    p.add_argument("--config", required=True, help="strategy config (TOML/YAML)")
+    p.add_argument("--data-dir", required=True, help="directory containing level2-*.jsonl or *.parquet")
+    p.add_argument("--max-rows", type=int, default=0, help="limit number of L2 rows for quick run (0=all)")
+    p.add_argument("--mode", choices=["grid", "optuna"], default="grid", help="sweep mode")
+    p.add_argument("--trials", type=int, default=30, help="number of trials for optuna")
+    p.add_argument("--seed", type=int, default=42, help="random seed for optuna")
+    # 既定グリッド（設計書の例）
+    p.add_argument("--grid-x", nargs="*", type=float, default=[0.15, 0.2, 0.25, 0.3], help="grid for signal.x")
+    p.add_argument("--grid-y", nargs="*", type=float, default=[1.0, 2.0, 3.0], help="grid for signal.y (ticks)")
+    p.add_argument("--grid-ttl", nargs="*", type=float, default=[0.6, 1.0, 1.4], help="grid for TTL seconds")
+    return p.parse_args()
+
+
+def main() -> None:
+    """〔この関数がすること〕 スイープを実行し、ベスト組合せと上位結果を表示します。"""
+    args = parse_args()
+    base_cfg = _load_config(args.config)
+
+    # データを一度だけ読込み → メモリ上に保持（試行間で再利用）
+    data_iter = load_level2_stream(Path(args.data_dir))
+    data = list(data_iter)  # 容量が大きい場合は --max-rows で制限
+    if args.max_rows and args.max_rows > 0:
+        data = data[: args.max_rows]
+
+    results: List[Tuple[float, Tuple[float, float, float], Dict[str, Any]]] = []
+
+    if args.mode == "grid":
+        for x, y, ttl in _grid(args.grid_x, args.grid_y, args.grid_ttl):
+            cfg_try = _apply_params(base_cfg, x, y, ttl)
+            score, summ = _evaluate(cfg_try, data)
+            results.append((score, (x, y, ttl), summ))
+    else:
+        # Optuna があれば TPE、無ければグリッドへフォールバック
+        try:
+            import optuna  # type: ignore
+
+            def _objective(trial: "optuna.trial.Trial") -> float:
+                x = trial.suggest_float("x", 0.10, 0.35)
+                y = trial.suggest_categorical("y", [1.0, 2.0, 3.0])
+                ttl = trial.suggest_float("ttl_s", 0.4, 1.6)
+                cfg_try = _apply_params(base_cfg, x, y, ttl)
+                score, summ = _evaluate(cfg_try, data)
+                # trial.user_attrs に要約を入れておくと後で取り出しやすい
+                trial.set_user_attr("summary", summ)
+                return score
+
+            sampler = optuna.samplers.TPESampler(seed=args.seed)
+            study = optuna.create_study(direction="maximize", sampler=sampler)
+            study.optimize(_objective, n_trials=args.trials)
+
+            # 結果取り出し
+            for t in study.trials:
+                params = (float(t.params.get("x", 0.0)), float(t.params.get("y", 0.0)), float(t.params.get("ttl_s", 0.0)))
+                summ = t.user_attrs.get("summary", {})
+                results.append((t.value if t.value is not None else -1e9, params, summ))
+        except Exception:
+            # フォールバック: グリッドへ
+            for x, y, ttl in _grid(args.grid_x, args.grid_y, args.grid_ttl):
+                cfg_try = _apply_params(base_cfg, x, y, ttl)
+                score, summ = _evaluate(cfg_try, data)
+                results.append((score, (x, y, ttl), summ))
+
+    # スコア順に並べ替え＆上位を表示
+    results.sort(key=lambda r: r[0], reverse=True)
+    top = results[:10]
+    print("Top results (score, x, y, ttl_s, trades, hit, avg_pnl_bps, slip_ticks, hold_ms, TPM, MaxDD):")
+    for sc, (x, y, ttl), s in top:
+        print("{:8.3f} | x={:.3f} y={:.1f} ttl={:.1f} | n={} hit={:.1%} pnl={:.2f}bps slip={:.2f} h={:.0f}ms tpm={:.2f} dd={:.1f}bps".format(
+            sc,
+            x, y, ttl,
+            s.get("trades", 0),
+            s.get("hit_rate", 0.0),
+            s.get("avg_pnl_bps", 0.0),
+            s.get("avg_slip_ticks", 0.0),
+            s.get("avg_holding_ms", 0.0),
+            s.get("trades_per_min", 0.0),
+            s.get("max_drawdown_bps", 0.0),
+        ))
+
+    if results:
+        best = results[0]
+        sc, (x, y, ttl), s = best
+        print("\nBEST:")
+        print(json.dumps({
+            "score": sc,
+            "params": {"x": x, "y": y, "ttl_s": ttl},
+            "summary": s,
+            "suggested_patch": {
+                "signal": {"x": x, "y": y},
+                "exec": {"order_ttl_ms": int(round(ttl * 1000.0))}
+            }
+        }, indent=2))
+        print("\nApply these into configs/strategy.toml under [signal]/[exec].")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/bots/vrlg/data_feed.py
+++ b/src/bots/vrlg/data_feed.py
@@ -9,7 +9,7 @@ strategy pipeline.
 from __future__ import annotations
 
 import asyncio
-import contextlib
+import contextlib  # 〔この import がすること〕 タスクキャンセル時の例外抑止に使います
 import math
 import time
 from dataclasses import dataclass, replace
@@ -68,12 +68,21 @@ def _get(obj: Any, key: str, default: Any = None) -> Any:
 async def _subscribe_level1(
     symbol: str,
     out: "asyncio.Queue[Tuple[float, float, float, float]]",
-    subscribe_level2,
+    subscribe_level2: Any | None = None,
 ) -> None:
     """Stream best bid/ask quotes from the exchange WebSocket."""
 
+    if not callable(subscribe_level2):
+        try:
+            from hl_core.api.ws import subscribe_level2 as subscribe_level2_fn  # type: ignore
+        except Exception as exc:
+            logger.warning("level2 WS adapter unavailable: %s", exc)
+            raise
+    else:
+        subscribe_level2_fn = subscribe_level2
+
     try:
-        async for book in subscribe_level2(symbol):
+        async for book in subscribe_level2_fn(symbol):
             bb = float(_get(book, "best_bid", 0.0))
             ba = float(_get(book, "best_ask", 0.0))
             bs = float(_get(book, "bid_size_l1", 0.0))
@@ -178,87 +187,58 @@ async def _feature_pump(
 
 
 async def run_feeds(cfg, out_queue: "asyncio.Queue[FeatureSnapshot]") -> None:
-    """Run the VRLG data feed with automatic synthetic fallback."""
-
+    """〔この関数がすること〕
+    - L2（最良気配）を購読して内部キューへ格納
+    - 100ms ごとに特徴量を生成して out_queue へ流す
+    - **WS が途中で落ちても** 合成フィードへ自動フォールバック
+    - タスクはキャンセルで安全に停止します
+    """
     symbol = getattr(getattr(cfg, "symbol", {}), "name", "BTCUSD-PERP")
     tick = float(getattr(getattr(cfg, "symbol", {}), "tick_size", 0.5))
-    lv1_queue: "asyncio.Queue[Tuple[float, float, float, float]]" = asyncio.Queue(maxsize=1024)
+    lv1_queue: "asyncio.Queue[tuple[float,float,float,float]]" = asyncio.Queue(maxsize=1024)
+
+    # 100ms 特徴生成は固定で起動
+    pump_task = asyncio.create_task(_feature_pump(cfg, out_queue, lv1_queue), name="feature_pump")
+
+    # まずは WS を試みる
+    producer_task = asyncio.create_task(_subscribe_level1(symbol, lv1_queue, tick), name="l2_subscriber")
+    producer_label = "ws"
 
     try:
-        from hl_core.api.ws import subscribe_level2  # type: ignore
-    except Exception as exc:
-        logger.warning("level2 WS adapter unavailable: %s; using synthetic L1", exc)
-        producer_task: Optional[asyncio.Task] = asyncio.create_task(
-            _synthetic_level1(lv1_queue, tick),
-            name="l1_synth",
-        )
-        using_synthetic = True
-    else:
-        producer_task = asyncio.create_task(
-            _subscribe_level1(symbol, lv1_queue, subscribe_level2),
-            name="l2_subscriber",
-        )
-        using_synthetic = False
+        while True:
+            # いずれかのタスクが例外で落ちたら処理
+            done, _ = await asyncio.wait({pump_task, producer_task}, return_when=asyncio.FIRST_EXCEPTION)
 
-        # Allow immediate import/connection failures to surface so we can fall back.
-        await asyncio.sleep(0)
-
-        if producer_task.done() and producer_task.exception():
-            logger.warning(
-                "level2 subscription failed instantly (%s); switching to synthetic feed",
-                producer_task.exception(),
-            )
-            producer_task = asyncio.create_task(
-                _synthetic_level1(lv1_queue, tick),
-                name="l1_synth",
-            )
-
-            using_synthetic = True
-
-    pump_task = asyncio.create_task(
-        _feature_pump(cfg, out_queue, lv1_queue),
-        name="feature_pump",
-    )
-
-    tasks = [pump_task, producer_task]
-
-    try:
-        while tasks:
-            done, pending = await asyncio.wait(
-                [t for t in tasks if t is not None],
-                return_when=asyncio.FIRST_EXCEPTION,
-            )
-
-            # If the producer failed and we were using WS, fall back to synthetic once.
-            if producer_task in done and producer_task:
-                exc = producer_task.exception()
+            # 生成側（pump）が落ちた → すべて終了
+            if pump_task in done:
+                exc = pump_task.exception()
+                if producer_task and not producer_task.done():
+                    producer_task.cancel()
+                    with contextlib.suppress(asyncio.CancelledError):
+                        await producer_task
                 if exc:
-                    if not using_synthetic:
-                        logger.warning(
-                            "level2 stream failed (%s); falling back to synthetic feed",
-                            exc,
-                        )
-                        producer_task = asyncio.create_task(
-                            _synthetic_level1(lv1_queue, tick),
-                            name="l1_synth",
-                        )
-                        using_synthetic = True
-                        tasks = [pump_task, producer_task]
-                        continue
                     raise exc
+                break
 
-            # If any task completed without exception we simply exit (likely cancellation).
-            if any(t.exception() for t in done if t is not producer_task):
-                for exc_task in done:
-                    exc = exc_task.exception()
-                    if exc:
-                        raise exc
-            break
+            # ここまで来たら producer 側が終了（例外含む）
+            exc = producer_task.exception()
+            if producer_label == "ws":
+                # WS が死んだ → 合成フィードへ切り替え
+                logger.warning("level2 WS failed (%s); switching to synthetic L1.", exc)
+            else:
+                logger.warning("synthetic L1 stopped unexpectedly (%s); restarting.", exc)
+
+            # 合成フィードを起動し直してループ継続
+            producer_task = asyncio.create_task(_synthetic_level1(lv1_queue, tick), name="l1_synth")
+            producer_label = "synthetic"
+
     except asyncio.CancelledError:
-        raise
+        # 正常停止（外部キャンセル）
+        pass
     finally:
-        for t in tasks:
-            if t:
+        # タスク後片付け
+        for t in (producer_task, pump_task):
+            if t and not t.done():
                 t.cancel()
-        with contextlib.suppress(asyncio.CancelledError):
-            await asyncio.gather(*[t for t in tasks if t], return_exceptions=True)
+                with contextlib.suppress(asyncio.CancelledError):
+                    await t


### PR DESCRIPTION
## Summary
- update the VRLG data feed to automatically fall back to the synthetic generator when the websocket stream fails and to shut down cleanly on cancellation
- import contextlib explicitly for cancellation handling and reuse the websocket subscriber when available

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dac804af588329a9e6af5217bccdfd