### PR TITLE
Fix VRLG feed fallback handling

### DIFF
--- a/src/bots/vrlg/data_feed.py
+++ b/src/bots/vrlg/data_feed.py
@@ -207,7 +207,7 @@ async def run_feeds(cfg, out_queue: "asyncio.Queue[FeatureSnapshot]") -> None:
     pump_task = asyncio.create_task(_feature_pump(cfg, out_queue, lv1_queue), name="feature_pump")
 
     # まずは WS を試みる
-    producer_task = asyncio.create_task(_subscribe_level1(symbol, lv1_queue, tick), name="l2_subscriber")
+    producer_task = asyncio.create_task(_subscribe_level1(symbol, lv1_queue), name="l2_subscriber")
     producer_label = "ws"
 
     try:

--- a/src/bots/vrlg/data_feed.py
+++ b/src/bots/vrlg/data_feed.py
@@ -76,7 +76,7 @@ async def _subscribe_level1(
 ) -> None:
     """Stream best bid/ask quotes from the exchange WebSocket."""
 
-    if subscribe_level2 is None:
+    if subscribe_level2 is None or not callable(subscribe_level2):
         try:
             from hl_core.api.ws import subscribe_level2 as subscribe_level2_fn  # type: ignore
         except Exception as exc:
@@ -207,7 +207,7 @@ async def run_feeds(cfg, out_queue: "asyncio.Queue[FeatureSnapshot]") -> None:
     pump_task = asyncio.create_task(_feature_pump(cfg, out_queue, lv1_queue), name="feature_pump")
 
     # まずは WS を試みる
-    producer_task = asyncio.create_task(_subscribe_level1(symbol, lv1_queue), name="l2_subscriber")
+    producer_task = asyncio.create_task(_subscribe_level1(symbol, lv1_queue, tick), name="l2_subscriber")
     producer_label = "ws"
 
     try:


### PR DESCRIPTION
## Summary
- ensure the WebSocket level1 producer falling back to the synthetic generator after failures
- guard the subscriber helper against non-callable overrides so the fallback works with the new callsite

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dba3af093c8329aac1087352b3e934