### PR TITLE
fix: propagate cancellation in PFPL position refresh loop

### DIFF
--- a/src/bots/pfpl/strategy.py
+++ b/src/bots/pfpl/strategy.py
@@ -297,6 +297,8 @@ class PFPLStrategy:
             await self._refresh_position()
             try:
                 await anyio.sleep(interval)
+            except asyncio.CancelledError:
+                raise
             except Exception as exc:  # pragma: no cover - defensive
                 logger.warning("position refresh sleep failed: %s", exc)
                 await asyncio.sleep(max(interval, 1))


### PR DESCRIPTION
## Summary
- allow `_position_refresh_loop` to propagate cancellation instead of swallowing it

## Testing
- poetry run pyright

------
https://chatgpt.com/codex/tasks/task_e_68dc39cb13f08329a3788e1573a0b9c3