### PR TITLE
chore: share DecisionLogger utility

### DIFF
--- a/src/bots/vrlg/strategy.py
+++ b/src/bots/vrlg/strategy.py
@@ -33,7 +33,7 @@ from .execution_engine import ExecutionEngine
 from .risk_management import RiskManager
 from .metrics import Metrics  # 〔この import がすること〕 Prometheus 送信ラッパを使えるようにする
 from .data_feed import run_feeds, FeatureSnapshot  # 〔この import がすること〕 L2購読→100ms特徴量生成（run_feeds）と特徴量型を使えるようにする
-from .decision_log import DecisionLogger  # 〔この import がすること〕 意思決定のJSONログを使えるようにする
+from hl_core.utils.decision_log import DecisionLogger  # 〔この import がすること〕 意思決定のJSONログを使えるようにする
 from .size_allocator import SizeAllocator  # 〔この import がすること〕 口座割合ベースのサイズ決定を使えるようにする
 
 logger = get_logger("VRLG")

--- a/src/hl_core/utils/decision_log.py
+++ b/src/hl_core/utils/decision_log.py
@@ -12,7 +12,7 @@ from typing import Any, Deque, Dict, List, Optional
 
 from hl_core.utils.logger import get_logger
 
-logger = get_logger("VRLG.decisions")
+logger = get_logger("DecisionLog")
 
 
 class DecisionLogger:


### PR DESCRIPTION
## Summary
- 移動済みの DecisionLogger を hl_core.utils に配置し、`get_logger("DecisionLog")` を使用する共通実装にしました
- VRLG 戦略から新しい共通ロガーを参照するよう import を更新しました

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd0c50a1b88329a703d51433205b71