### PR TITLE
Align DecisionLogger shared utility comments

### DIFF
--- a/src/bots/vrlg/strategy.py
+++ b/src/bots/vrlg/strategy.py
@@ -33,7 +33,7 @@ from .execution_engine import ExecutionEngine
 from .risk_management import RiskManager
 from .metrics import Metrics  # 〔この import がすること〕 Prometheus 送信ラッパを使えるようにする
 from .data_feed import run_feeds, FeatureSnapshot  # 〔この import がすること〕 L2購読→100ms特徴量生成（run_feeds）と特徴量型を使えるようにする
-from hl_core.utils.decision_log import DecisionLogger  # 〔この import がすること〕 意思決定のJSONログを使えるようにする
+from hl_core.utils.decision_log import DecisionLogger  # 〔この import がすること〕 共通ロガー（PFPL等と共有）を利用する
 from .size_allocator import SizeAllocator  # 〔この import がすること〕 口座割合ベースのサイズ決定を使えるようにする
 
 logger = get_logger("VRLG")

--- a/src/hl_core/utils/decision_log.py
+++ b/src/hl_core/utils/decision_log.py
@@ -1,7 +1,6 @@
 
 # 〔このモジュールがすること〕
-# VRLG の意思決定イベントを「1行JSON」で記録します（リングバッファ + 任意でファイル書き出し）。
-# ログ項目例: signal/order_intent/order_submitted/exit/risk_pause/fill/block_interval など。
+# Bot 横断で使える「意思決定イベントの1行JSONロガー」を提供します（リングバッファ + 任意のJSONL追記）。
 
 from __future__ import annotations
 


### PR DESCRIPTION
## Summary
- refresh the shared DecisionLogger module header comment to emphasize cross-bot usage
- clarify VRLG strategy's import comment to note reuse of the shared logger

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd4d99f7508329b4002e2bad26325e