### PR TITLE
Implement VRLG SizeAllocator shared sizing logic

### DIFF
--- a/src/bots/vrlg/size_allocator.py
+++ b/src/bots/vrlg/size_allocator.py
@@ -1,60 +1,73 @@
 # 〔このモジュールがすること〕
-# 口座残高（USD想定）に対して 0.2–0.5% を基準に「1クリップの発注量（BTC）」を決めます。
-# - PFPL など他Botでも再利用可能な独立ユニット
-# - APIが無い環境でも動くよう equity_usd は設定値/既定値から取得（後でAPIに差し替え可能）
+# 口座残高（USD）と設定（percent_min/percent_max/min_clip_btc/max_exposure_btc）から、
+# VRLG の 1 クリップ（子注文の親となる“クリップ総量”）サイズ（BTC）を決定します。
+# RiskManager から渡される size_multiplier を掛け、最終的な BTC 数量を返します。
 
 from __future__ import annotations
 
 from typing import Any
 
+from hl_core.utils.logger import get_logger
 
-def _get(cfg: Any, section: str, key: str, default):
-    """〔この関数がすること〕 設定（dict/属性どちらでもOK）から値を安全に取り出します。"""
-    try:
-        sec = getattr(cfg, section)
-        return getattr(sec, key, default)
-    except Exception:
-        try:
-            return cfg[section].get(key, default)  # type: ignore[index]
-        except Exception:
-            return default
+logger = get_logger("VRLG.size")
 
 
 class SizeAllocator:
     """〔このクラスがすること〕
-    1トレード（クリップ）あたりのサイズ（BTC）を決めます。
-    - percent_min / percent_max: 口座残高に対する割合（0.002=0.2% 〜 0.005=0.5%）
-    - splits: クリップ分割数（>1 のとき、算出サイズを均等割り）
-    - max_exposure_btc / min_clip_btc で上下限をクランプ
+    設定と口座残高に基づいて「次に出すクリップサイズ（BTC）」を算出します。
     """
 
-    def __init__(self, cfg) -> None:
-        """〔このメソッドがすること〕 各パラメータを設定から読み込み、既定値を用意します。"""
-        self.percent_min: float = float(_get(cfg, "exec", "percent_min", 0.002))  # 0.2%
-        self.percent_max: float = float(_get(cfg, "exec", "percent_max", 0.005))  # 0.5%
-        self.splits: int = int(_get(cfg, "exec", "splits", 1))
-        self.min_clip_btc: float = float(_get(cfg, "exec", "min_clip_btc", 0.001))
-        self.max_exposure_btc: float = float(_get(cfg, "exec", "max_exposure_btc", 0.8))
-        # equity_usd は将来 API で差し替え可能。いまは設定 or 既定値で運用
-        self.equity_usd: float = float(
-            _get(cfg, "exec", "equity_usd", _get(cfg, "risk", "equity_usd", 10000.0))
-        )
+    def __init__(self, cfg: Any) -> None:
+        """〔このメソッドがすること〕 設定値を読み込み、既定の口座残高USDを保持します。"""
+        self.cfg = cfg
+        ex = getattr(cfg, "exec", {})
+        self.percent_min = float(getattr(ex, "percent_min", 0.002))   # 0.2%
+        self.percent_max = float(getattr(ex, "percent_max", 0.005))   # 0.5%
+        self.min_clip_btc = float(getattr(ex, "min_clip_btc", 0.001))
+        self.max_exposure_btc = float(getattr(ex, "max_exposure_btc", 0.8))
+        self._equity_usd = float(getattr(ex, "equity_usd", 10_000.0))
+
+    def update_equity_usd(self, equity_usd: float) -> None:
+        """〔このメソッドがすること〕 外部（口座API等）から最新の口座残高USDを注入します。"""
+        try:
+            self._equity_usd = max(0.0, float(equity_usd))
+        except Exception as e:
+            logger.debug("equity update failed: %s", e)
 
     def next_size(self, mid: float, risk_mult: float = 1.0) -> float:
         """〔このメソッドがすること〕
-        現在のミッド価格（USD）とリスク倍率から、1クリップの BTC 数量を返します。
-        - 中心割合 = (percent_min + percent_max)/2
-        - 口座残高×中心割合×risk_mult を USD→BTC に換算
-        - splits>1 のとき均等割り
-        - min_clip_btc〜max_exposure_btc にクランプ
+        クリップ総量（BTC）を返します。手順:
+          1) pct = clamp(percent_max * risk_mult, lower=percent_min, upper=percent_max)
+          2) notional_usd = equity_usd * pct
+          3) size_btc = notional_usd / mid
+          4) size_btc < min_clip_btc → 0 を返す（発注スキップ）
+          5) size_btc を max_exposure_btc で上限クランプ
         """
-        if mid <= 0 or self.equity_usd <= 0:
+        try:
+            midf = float(mid)
+            if midf <= 0.0 or self._equity_usd <= 0.0:
+                return 0.0
+
+            # 1) パーセンテージ（Risk で 0.5 などに縮む想定）
+            pct = self.percent_max * float(risk_mult)
+            if pct < self.percent_min:
+                pct = self.percent_min
+            if pct > self.percent_max:
+                pct = self.percent_max
+
+            # 2) USD → 3) BTC
+            notional = self._equity_usd * pct
+            size_btc = notional / midf
+
+            # 4) 取引所の最小発注仕様などに配慮して、閾値未満はスキップ
+            if size_btc < self.min_clip_btc:
+                return 0.0
+
+            # 5) 露出上限でクランプ（最終安全弁。実際の露出管理は ExecutionEngine 側でも実施）
+            size_btc = min(size_btc, self.max_exposure_btc)
+
+            # 数値安定のため軽く丸め
+            return float(round(size_btc, 6))
+        except Exception as e:
+            logger.debug("size allocation failed: %s", e)
             return 0.0
-        base_pct = 0.5 * (self.percent_min + self.percent_max)
-        usd = self.equity_usd * base_pct * max(risk_mult, 0.0)
-        btc = usd / mid
-        if self.splits > 1:
-            btc /= float(self.splits)
-        # クリップの下限/上限を適用
-        btc = max(self.min_clip_btc, min(btc, self.max_exposure_btc))
-        return max(0.0, btc)

--- a/src/bots/vrlg/strategy.py
+++ b/src/bots/vrlg/strategy.py
@@ -33,8 +33,8 @@ from .execution_engine import ExecutionEngine
 from .risk_management import RiskManager
 from .metrics import Metrics  # 〔この import がすること〕 Prometheus 送信ラッパを使えるようにする
 from .data_feed import run_feeds, FeatureSnapshot  # 〔この import がすること〕 L2購読→100ms特徴量生成（run_feeds）と特徴量型を使えるようにする
-from hl_core.utils.decision_log import DecisionLogger  # 〔この import がすること〕 意思決定のJSONログを使えるようにする
-from .size_allocator import SizeAllocator  # 〔この import がすること〕 口座割合ベースのサイズ決定を使えるようにする
+from hl_core.utils.decision_log import DecisionLogger  # 〔この import がすること〕 共通ロガー（PFPL等と共有）を利用する
+from .size_allocator import SizeAllocator  # 〔この import がすること〕 クリップサイズ算出ロジックを利用する
 
 logger = get_logger("VRLG")
 
@@ -81,7 +81,7 @@ class VRLGStrategy:
         # 〔この行がすること〕 発注イベント（skip/submitted/reject/cancel）を Strategy で受け取れるよう接続
         self.exe.on_order_event = self._on_order_event
         self.risk = RiskManager(self.cfg)
-        self.sizer = SizeAllocator(self.cfg)  # 〔この行がすること〕 0.2–0.5% 基準のサイズ決定器を用意
+        self.sizer = SizeAllocator(self.cfg)  # 〔この行がすること〕 発注直前に使うサイズ決定器を初期化
 
     async def start(self) -> None:
         """〔このメソッドがすること〕

--- a/src/hl_core/utils/decision_log.py
+++ b/src/hl_core/utils/decision_log.py
@@ -1,7 +1,6 @@
 
 # 〔このモジュールがすること〕
-# VRLG の意思決定イベントを「1行JSON」で記録します（リングバッファ + 任意でファイル書き出し）。
-# ログ項目例: signal/order_intent/order_submitted/exit/risk_pause/fill/block_interval など。
+# Bot 横断で使える「意思決定イベントの1行JSONロガー」を提供します（リングバッファ + 任意のJSONL追記）。
 
 from __future__ import annotations
 

--- a/tests/integration/test_strategy_flow.py
+++ b/tests/integration/test_strategy_flow.py
@@ -86,7 +86,7 @@ def _cfg_dict() -> dict:
             "percent_max": 0.005,
             "splits": 1,
             "min_clip_btc": 0.001,
-            "equity_usd": 10000.0,
+            "equity_usd": 20000.0,  # 0.5% × equity → 0.0014BTC として最小クリップを上回るように調整
         },
         "risk": {
             "max_slippage_ticks": 1.0,


### PR DESCRIPTION
## Summary
- replace the VRLG SizeAllocator with the shared clamp-and-round sizing implementation
- wire VRLG strategy to the new allocator comment annotations for clarity
- raise the VRLG strategy integration test equity to satisfy the allocator minimum clip requirement

## Testing
- poetry run pytest -q -m "not live" --maxfail=1


------
https://chatgpt.com/codex/tasks/task_e_68dd4d99f7508329b4002e2bad26325e