### PR TITLE
Add guard to skip signals when rotation inactive

### DIFF
--- a/src/bots/vrlg/strategy.py
+++ b/src/bots/vrlg/strategy.py
@@ -172,6 +172,10 @@ class VRLGStrategy:
 
                 sig = self.sigdet.update_and_maybe_signal(float(feat.t), feat)
                 if sig:
+                    # 〔このブロックがすること〕 R*（周期検出）が非アクティブの間は執行せずスキップする
+                    if not self.rot.is_active():
+                        self.decisions.log("rotation_paused", reason="inactive", trace_id=getattr(sig, "trace_id", None))
+                        continue
                     self.decisions.log(
                         "signal",
                         phase=phase,


### PR DESCRIPTION
## Summary
- add a guard in the strategy to skip acting on signals when the rotation detector is inactive

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ded0d524048329b3a132bb7ee04da3