### PR TITLE
Add debug signal evaluation helper for PFPL strategy

### DIFF
--- a/src/bots/pfpl/strategy.py
+++ b/src/bots/pfpl/strategy.py
@@ -66,8 +66,6 @@ class PFPLStrategy:
         last_order_ts: float | None,
         funding_blocked: bool,
     ) -> dict:
-        import time, logging
-
         logger = getattr(self, "logger", None) or getattr(self, "log", None) or logging.getLogger(__name__)
         now = time.time()
 

--- a/src/bots/pfpl/strategy.py
+++ b/src/bots/pfpl/strategy.py
@@ -50,6 +50,87 @@ logger = logging.getLogger(__name__)
 class PFPLStrategy:
     """Price-Fair-Price-Lag bot"""
 
+    # 何をする関数か:
+    # - mid と fair の乖離（絶対値/率）を計算
+    # - threshold / threshold_pct / spread_threshold の合否を判定
+    # - cooldown / 最大ポジション / 最小発注額 / funding guard の合否を判定
+    # - 上記の内訳を1行の DEBUG ログに要約出力（発注はしない）
+    # - 後段の判定/発注で再利用できる dict を返す
+    def _debug_evaluate_signal(
+        self,
+        *,
+        mid_px: float,
+        fair_px: float,
+        order_usd: float,
+        pos_usd: float,
+        last_order_ts: float | None,
+        funding_blocked: bool,
+    ) -> dict:
+        import time, logging
+
+        logger = getattr(self, "logger", None) or getattr(self, "log", None) or logging.getLogger(__name__)
+        now = time.time()
+
+        diff_abs = mid_px - fair_px
+        diff_pct = (diff_abs / fair_px) if fair_px else 0.0
+
+        thr_abs = getattr(self, "threshold", 0.0)
+        thr_pct = getattr(self, "threshold_pct", 0.0)
+        spread_thr = getattr(self, "spread_threshold", 0.0)
+        cooldown = getattr(self, "cooldown_sec", 0.0)
+        max_pos = getattr(self, "max_position_usd", float("inf"))
+        min_usd = getattr(self, "min_usd", 0.0)
+
+        cooldown_ok = (now - (last_order_ts or 0.0)) >= cooldown
+        abs_ok = (abs(diff_abs) >= thr_abs) if thr_abs else False
+        pct_ok = (abs(diff_pct) >= thr_pct) if thr_pct else False
+        spread_ok = (abs(diff_abs) >= spread_thr) if spread_thr else True
+        pos_ok = (abs(pos_usd) + order_usd) <= max_pos
+        notional_ok = order_usd >= min_usd
+        funding_ok = not funding_blocked
+
+        # 方向の示唆（情報表示のみ）
+        want_long = (diff_abs <= -thr_abs) or (diff_pct <= -thr_pct if thr_pct else False)
+        want_short = (diff_abs >= thr_abs) or (diff_pct >= thr_pct if thr_pct else False)
+
+        logger.debug(
+            "decision mid=%.2f fair=%.2f d_abs=%+.4f d_pct=%+.5f | "
+            "abs>=%.4f:%s pct>=%.5f:%s spread>=%.4f:%s | "
+            "cooldown_ok=%s pos_ok=%s notional_ok=%s funding_ok=%s | "
+            "long=%s short=%s",
+            mid_px,
+            fair_px,
+            diff_abs,
+            diff_pct,
+            thr_abs,
+            abs_ok,
+            thr_pct,
+            pct_ok,
+            spread_thr,
+            spread_ok,
+            cooldown_ok,
+            pos_ok,
+            notional_ok,
+            funding_ok,
+            want_long,
+            want_short,
+        )
+
+        return {
+            "diff_abs": diff_abs,
+            "diff_pct": diff_pct,
+            "abs_ok": abs_ok,
+            "pct_ok": pct_ok,
+            "spread_ok": spread_ok,
+            "cooldown_ok": cooldown_ok,
+            "pos_ok": pos_ok,
+            "notional_ok": notional_ok,
+            "funding_ok": funding_ok,
+            "want_long": want_long,
+            "want_short": want_short,
+            "ts": now,
+        }
+
     # ← シグネチャはそのまま
     _LOGGER_INITIALISED = False
     _FILE_HANDLERS: set[str] = set()


### PR DESCRIPTION
## Summary
- add a helper on PFPLStrategy to compute and log signal breakdown details
- expose the computed guard evaluations for later decision logic reuse

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dee2ee0df483298e78ddaffb2ff943