### PR TITLE
Convert file log outputs to CSV format

### DIFF
--- a/src/bots/pfpl/strategy.py
+++ b/src/bots/pfpl/strategy.py
@@ -15,7 +15,7 @@ from typing import Any, cast
 
 import anyio
 from hl_core.config import load_settings
-from hl_core.utils.logger import setup_logger, get_logger
+from hl_core.utils.logger import create_csv_formatter, setup_logger, get_logger
 # 既存 import 群の最後あたりに追加
 from hyperliquid.exchange import Exchange
 
@@ -48,7 +48,7 @@ logger = get_logger(__name__)
 
 
 
-# 役割: この関数は PFPL 戦略ロガーの親への伝播を止め、二重ログ（runner.log / pfpl.log など）を防ぎます
+# 役割: この関数は PFPL 戦略ロガーの親への伝播を止め、二重ログ（runner.csv / pfpl.csv など）を防ぎます
 def _lock_strategy_logger_to_self(target: logging.Logger) -> None:
     """戦略ロガーのログが親ロガーへ伝播しないようにする（重複出力の抑止）。"""
 
@@ -341,7 +341,7 @@ class PFPLStrategy:
                 )
 
         # ─── ここから追加（ロガーをペアごとのファイルへも出力）────
-        handler_filename = f"strategy_{self.symbol}.log"
+        handler_filename = f"strategy_{self.symbol}.csv"
         module_logger = logger
         existing_handler = next(
             (
@@ -355,9 +355,7 @@ class PFPLStrategy:
 
         if existing_handler is None:
             handler = logging.FileHandler(handler_filename, encoding="utf-8")
-            handler.setFormatter(
-                logging.Formatter("%(asctime)s %(levelname)s %(message)s")
-            )
+            handler.setFormatter(create_csv_formatter(include_logger_name=False))
             module_logger.addHandler(handler)
 
         PFPLStrategy._FILE_HANDLERS.add(self.symbol)

--- a/tests/unit/test_logger.py
+++ b/tests/unit/test_logger.py
@@ -128,7 +128,7 @@ def test_setup_logger_switches_rotating_handler_for_new_bot(tmp_path, monkeypatc
 
     assert len(file_handlers) == 1
     handler = file_handlers[0]
-    expected_pfpl = str((log_root / "pfpl" / "pfpl.log").resolve())
+    expected_pfpl = str((log_root / "pfpl" / "pfpl.csv").resolve())
 
     assert handler.baseFilename == expected_pfpl
 
@@ -165,8 +165,8 @@ def test_runner_logs_do_not_leak_into_other_bot_log(tmp_path, monkeypatch):
         if isinstance(handler, logging.FileHandler):
             handler.flush()
 
-    pfpl_log = (log_root / "pfpl" / "pfpl.log").resolve()
-    runner_log = (log_root / "runner" / "runner.log").resolve()
+    pfpl_log = (log_root / "pfpl" / "pfpl.csv").resolve()
+    runner_log = (log_root / "runner" / "runner.csv").resolve()
 
     assert pfpl_log.exists()
     assert file_handlers[0].baseFilename == str(pfpl_log)

--- a/tests/unit/test_pfpl_evaluate.py
+++ b/tests/unit/test_pfpl_evaluate.py
@@ -30,7 +30,7 @@ def strategy(monkeypatch: pytest.MonkeyPatch) -> Iterator[PFPLStrategy]:
     for handler in list(root_logger.handlers):
         filename = getattr(handler, "baseFilename", "")
         if isinstance(handler, logging.FileHandler) and filename.endswith(
-            f"strategy_{strat.symbol}.log"
+            f"strategy_{strat.symbol}.csv"
         ):
             root_logger.removeHandler(handler)
             handler.close()

--- a/tests/unit/test_pfpl_init.py
+++ b/tests/unit/test_pfpl_init.py
@@ -31,7 +31,7 @@ def _set_credentials(
 def _remove_strategy_handler(symbol: str = "ETH-PERP") -> None:
     PFPLStrategy._FILE_HANDLERS.discard(symbol)
     module_logger = strategy_module.logger
-    handler_suffix = f"strategy_{symbol}.log"
+    handler_suffix = f"strategy_{symbol}.csv"
     for handler in list(module_logger.handlers):
         if isinstance(handler, logging.FileHandler) and getattr(
             handler, "baseFilename", ""
@@ -51,7 +51,7 @@ def test_init_adds_file_handler_once(monkeypatch):
     sem = Semaphore(1)
     module_logger = strategy_module.logger
     symbol = "ETH-PERP"
-    handler_suffix = f"strategy_{symbol}.log"
+    handler_suffix = f"strategy_{symbol}.csv"
 
     def _count_handlers() -> int:
         return sum(
@@ -124,7 +124,7 @@ def test_caplog_keeps_symbol_file_logging(monkeypatch, caplog):
 
         assert strategy is not None
 
-        log_path = Path(f"strategy_{strategy.symbol}.log")
+        log_path = Path(f"strategy_{strategy.symbol}.csv")
         assert log_path.exists()
         content = log_path.read_text(encoding="utf-8")
         assert log_message in content


### PR DESCRIPTION
## Summary
- add a reusable CSV formatter for logging and apply it to rotating/error handlers
- switch PFPL strategy log files and related expectations to the new .csv extension

## Testing
- pytest tests/unit/test_logger.py tests/unit/test_pfpl_init.py tests/unit/test_pfpl_evaluate.py

------
https://chatgpt.com/codex/tasks/task_e_68e0038834948329b8059d9c8be53b0c