### PR TITLE
Adjust PFPL signal thresholds

### DIFF
--- a/src/bots/pfpl/config.yaml
+++ b/src/bots/pfpl/config.yaml
@@ -3,15 +3,16 @@
 mode: abs
 testnet: false             # true: testnet / false: mainnet
 target_symbol: "ETH-PERP"  # 取引するペア
-fair_feed: indexPrices     # fair price に用いるフィード
+fair_feed: oraclePrices     # 役割: fair（公正価格）のソースを index→oracle に変更し、短期の乖離を拾いやすくする
 spread_threshold: 0.05     # インデックス乖離率 (%)
 
 
 # ── 売買判定閾値 ───────────────────────────────
-# エントリーの絶対しきい値（USD）。この値以上の有利差でのみ新規建てします。
-threshold: 0.25
+# 役割: エントリーの絶対しきい値（USD）を 0.01（1ティック）に下げ、発火頻度をさらに高める
+threshold: 0.01
 threshold_pct: 0.001       # 割合 (%) ─ 上記 threshold と併用可
-cooldown_sec: 1.0          # 連続発注のクールダウン秒
+# 役割: 連続発注のクールダウン秒数を短縮（1.0 → 0.33）し、条件が続くときの発火頻度を最大3回/秒に調整
+cooldown_sec: 0.33
 max_order_per_sec: 3       # 取引所 API 制限に合わせた同時発注上限
 
 # ── ポジション & サイズ管理 ────────────────────


### PR DESCRIPTION
## Summary
- switch the PFPL fair price source to `oraclePrices` so signals react to faster oracle updates
- lower the absolute entry threshold to $0.01 and shorten the cooldown to 0.33s to allow more frequent order placement

## Testing
- not run (configuration change only)


------
https://chatgpt.com/codex/tasks/task_e_68e0bfff9628832983ce41e46a4a70e4