### PR TITLE
fix: allow PFPL strategy to use symbol-only price updates

### DIFF
--- a/src/bots/pfpl/strategy.py
+++ b/src/bots/pfpl/strategy.py
@@ -457,6 +457,8 @@ class PFPLStrategy:
         elif ch == "indexPrices":  # インデックス価格
             prices = (msg.get("data") or {}).get("prices") or {}
             price_val = prices.get(self.base_coin)
+            if price_val is None:
+                price_val = prices.get(self.symbol)
             new_idx = Decimal(str(price_val)) if price_val is not None else None
             if new_idx != self.idx:
                 self.idx = new_idx
@@ -466,6 +468,8 @@ class PFPLStrategy:
         elif ch == "oraclePrices":  # オラクル価格
             prices = (msg.get("data") or {}).get("prices") or {}
             price_val = prices.get(self.base_coin)
+            if price_val is None:
+                price_val = prices.get(self.symbol)
             new_ora = Decimal(str(price_val)) if price_val is not None else None
             if new_ora != self.ora:
                 self.ora = new_ora


### PR DESCRIPTION
## Summary
- fall back to symbol keys when index/oracle price feeds omit the base coin
- keep fair price inputs in sync by converting fallback values to Decimal and triggering evaluation
- add unit tests covering symbol-only index and oracle messages updating the fair price and calling evaluate

## Testing
- pytest tests/unit/test_pfpl_on_message.py::test_on_message_fair_updates_when_symbol_only_index
- pytest tests/unit/test_pfpl_on_message.py::test_on_message_fair_updates_when_symbol_only_oracle

------
https://chatgpt.com/codex/tasks/task_e_68e2ae795cb48329ae7d2b0076979cf5