### PR TITLE
Fix funding guard configuration handling

### DIFF
--- a/src/bots/pfpl/strategy.py
+++ b/src/bots/pfpl/strategy.py
@@ -65,6 +65,26 @@ def _maybe_enable_test_propagation() -> None:
         logger.propagate = True
 
 
+def _coerce_bool(value: Any, *, default: bool) -> bool:
+    """設定値を真偽値へ変換するヘルパー。"""
+
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return bool(value)
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"", "0", "false", "off", "no"}:
+            return False
+        if normalized in {"1", "true", "on", "yes"}:
+            return True
+        # それ以外の文字列は Python の bool キャストに合わせる
+        return bool(normalized)
+    return bool(value)
+
+
 class PFPLStrategy:
     """Price-Fair-Price-Lag bot"""
 
@@ -167,11 +187,21 @@ class PFPLStrategy:
                 raw_conf = f.read()
             yaml_conf = yaml.safe_load(raw_conf) or {}
         self.config = {**config, **yaml_conf}
-        # --- Funding 直前クローズ用バッファ秒数（デフォルト 120）
+        funding_guard_cfg = self.config.get("funding_guard", {})
+        if not isinstance(funding_guard_cfg, dict):
+            funding_guard_cfg = {}
+        self.funding_guard_enabled: bool = _coerce_bool(
+            funding_guard_cfg.get("enabled"), default=True
+        )
+        self.funding_guard_buffer_sec: int = int(
+            funding_guard_cfg.get("buffer_sec", 300)
+        )
+        self.funding_guard_reenter_sec: int = int(
+            funding_guard_cfg.get("reenter_sec", 120)
+        )
+        legacy_close_buffer = self.config.get("funding_close_buffer_secs", 120)
         self.funding_close_buffer_secs: int = int(
-            getattr(self, "cfg", getattr(self, "config", {})).get(
-                "funding_close_buffer_secs", 120
-            )
+            funding_guard_cfg.get("buffer_sec", legacy_close_buffer)
         )
         # --- Order price offset percentage（デフォルト 0.0005 = 0.05 %）
         self.eps_pct: float = float(self.config.get("eps_pct", 0.0005))
@@ -789,12 +819,16 @@ class PFPLStrategy:
         funding 直前・直後は True を返さず evaluate() を停止させる。
         - 5 分前 〜 2 分後 を「危険窓」とする
         """
+        if not self.funding_guard_enabled:
+            if self._funding_pause:
+                self._funding_pause = False
+            return True
         if self.next_funding_ts is None:
             return True  # fundingInfo 未取得なら通常運転
 
         now = time.time()
-        before = 300  # 5 分前
-        after = 120  # 2 分後
+        before = self.funding_guard_buffer_sec
+        after = self.funding_guard_reenter_sec
 
         in_window = self.next_funding_ts - before <= now <= self.next_funding_ts + after
 
@@ -812,10 +846,12 @@ class PFPLStrategy:
     # ------------------------------------------------------------------
     def _should_close_before_funding(self, now_ts: float) -> bool:
         """Return True if we are within the configured buffer before funding."""
+        if not self.funding_guard_enabled:
+            return False
         next_ts = getattr(self, "next_funding_ts", None)
         if not next_ts:
             return False
-        return now_ts > next_ts - self.funding_close_buffer_secs
+        return now_ts > next_ts - self.funding_guard_buffer_sec
 
     async def _close_all_positions(self) -> None:
         """Close every open position for this symbol."""

--- a/tests/unit/test_pfpl_init.py
+++ b/tests/unit/test_pfpl_init.py
@@ -257,3 +257,106 @@ async def test_refresh_position_uses_base_coin(monkeypatch):
     finally:
         _remove_strategy_handler(strategy.symbol)
         PFPLStrategy._FILE_HANDLERS.clear()
+
+
+def test_funding_guard_config_applied(monkeypatch):
+    _set_credentials(monkeypatch, "HL_ACCOUNT_ADDRESS", "HL_PRIVATE_KEY")
+
+    monkeypatch.setattr(strategy_module.yaml, "safe_load", lambda raw_conf: {})
+    PFPLStrategy._FILE_HANDLERS.clear()
+    _remove_strategy_handler()
+
+    strategy = None
+    strategy_disabled = None
+    now = 1_700_000_000.0
+
+    try:
+        strategy = PFPLStrategy(
+            config={
+                "funding_guard": {
+                    "enabled": True,
+                    "buffer_sec": 60,
+                    "reenter_sec": 15,
+                }
+            },
+            semaphore=Semaphore(1),
+        )
+
+        assert strategy.funding_guard_enabled is True
+        assert strategy.funding_guard_buffer_sec == 60
+        assert strategy.funding_guard_reenter_sec == 15
+        assert strategy.funding_close_buffer_secs == 60
+
+        strategy.next_funding_ts = now + 30
+        monkeypatch.setattr(strategy_module.time, "time", lambda: now)
+        assert strategy._check_funding_window() is False
+        assert strategy._funding_pause is True
+
+        monkeypatch.setattr(strategy_module.time, "time", lambda: now + 61)
+        assert strategy._check_funding_window() is True
+        assert strategy._funding_pause is False
+
+        assert strategy._should_close_before_funding(now) is True
+
+        strategy_disabled = PFPLStrategy(
+            config={
+                "funding_guard": {
+                    "enabled": False,
+                    "buffer_sec": 45,
+                    "reenter_sec": 10,
+                }
+            },
+            semaphore=Semaphore(1),
+        )
+
+        strategy_disabled.next_funding_ts = now + 5
+        monkeypatch.setattr(strategy_module.time, "time", lambda: now)
+
+        assert strategy_disabled._check_funding_window() is True
+        assert strategy_disabled._should_close_before_funding(now) is False
+    finally:
+        if strategy is not None:
+            _remove_strategy_handler(strategy.symbol)
+        if strategy_disabled is not None:
+            _remove_strategy_handler(strategy_disabled.symbol)
+        PFPLStrategy._FILE_HANDLERS.clear()
+
+
+def test_funding_guard_string_config_handled(monkeypatch):
+    _set_credentials(monkeypatch, "HL_ACCOUNT_ADDRESS", "HL_PRIVATE_KEY")
+
+    monkeypatch.setattr(strategy_module.yaml, "safe_load", lambda raw_conf: {})
+    PFPLStrategy._FILE_HANDLERS.clear()
+    _remove_strategy_handler()
+
+    strategy = None
+    now = 1_700_000_000.0
+
+    try:
+        strategy = PFPLStrategy(
+            config={
+                "funding_guard": {
+                    "enabled": "false",
+                    "buffer_sec": "90",
+                    "reenter_sec": "45",
+                }
+            },
+            semaphore=Semaphore(1),
+        )
+
+        assert strategy.funding_guard_enabled is False
+        assert strategy.funding_guard_buffer_sec == 90
+        assert strategy.funding_guard_reenter_sec == 45
+        assert strategy.funding_close_buffer_secs == 90
+
+        strategy._funding_pause = True
+        strategy.next_funding_ts = now + 5
+        monkeypatch.setattr(strategy_module.time, "time", lambda: now)
+
+        assert strategy._check_funding_window() is True
+        assert strategy._funding_pause is False
+        assert strategy._should_close_before_funding(now) is False
+    finally:
+        if strategy is not None:
+            _remove_strategy_handler(strategy.symbol)
+        PFPLStrategy._FILE_HANDLERS.clear()


### PR DESCRIPTION
## Summary
- normalize the PFPL strategy funding guard `enabled` flag to honour string and numeric inputs and clear any active pause when the guard is disabled
- keep using the configured buffer/re-entry values when parsed from strings
- cover the string-based configuration and pause reset behaviour with an additional unit test

## Testing
- pytest tests/unit/test_pfpl_init.py::test_funding_guard_config_applied tests/unit/test_pfpl_init.py::test_funding_guard_string_config_handled

------
https://chatgpt.com/codex/tasks/task_e_68e31b70a0a48329959018664d11b02f