### PR TITLE
Add evaluate snapshot logging for PFPL strategy

### DIFF
--- a/src/bots/pfpl/strategy.py
+++ b/src/bots/pfpl/strategy.py
@@ -628,6 +628,15 @@ class PFPLStrategy:
         if mid is None or fair is None:
             return  # データが揃っていない
 
+        self._debug_evaluate_signal(
+            mid_px=float(mid),
+            fair_px=float(fair),
+            order_usd=float(self.order_usd),
+            pos_usd=float(self.pos_usd),
+            last_order_ts=self.last_ts or None,
+            funding_blocked=self._funding_pause,
+        )
+
         diff = fair - mid  # USD 差（符号付き）
         diff_pct = diff / mid * Decimal("100")  # 乖離率 %（符号付き）
         abs_diff = abs(diff)
@@ -637,17 +646,6 @@ class PFPLStrategy:
         th_abs = Decimal(str(self.config.get("threshold", "1.0")))  # USD
         th_pct = Decimal(str(self.config.get("threshold_pct", "0.05")))  # %
         mode = self.config.get("mode", "both")  # both / either
-
-        logger.debug(
-            "signal: diff=%+.6f diff_pct=%+.6f thr=%.6f thr_pct=%.6f pos_usd=%+.2f order_usd=%.2f dry_run=%s",
-            diff,
-            diff_pct,
-            th_abs,
-            th_pct,
-            self.pos_usd,
-            self.order_usd,
-            self.dry_run,
-        )
 
         if mode == "abs":
             if abs_diff < th_abs:

--- a/tests/unit/test_pfpl_evaluate.py
+++ b/tests/unit/test_pfpl_evaluate.py
@@ -48,10 +48,11 @@ def test_evaluate_logs_signed_diff(
 
     assert any(
         record.levelno == logging.DEBUG
-        and "diff=+1.000000" in record.message
-        and "diff_pct=+1.000000" in record.message
+        and "decision" in record.message
+        and "d_abs=-1.0000" in record.message
+        and "d_pct=-0.00990" in record.message
         for record in caplog.records
-    ), "expected positive diff log"
+    ), "expected positive diff snapshot log"
 
     caplog.clear()
 
@@ -61,10 +62,11 @@ def test_evaluate_logs_signed_diff(
 
     assert any(
         record.levelno == logging.DEBUG
-        and "diff=-1.000000" in record.message
-        and "diff_pct=-1.000000" in record.message
+        and "decision" in record.message
+        and "d_abs=+1.0000" in record.message
+        and "d_pct=+0.01010" in record.message
         for record in caplog.records
-    ), "expected negative diff log"
+    ), "expected negative diff snapshot log"
 
 
 def test_evaluate_quantizes_size_with_qty_tick(


### PR DESCRIPTION
## Summary
- emit the decision snapshot from `_debug_evaluate_signal` when `evaluate` runs and remove the redundant signal log
- adjust the unit test expectations to look for the new snapshot output

## Testing
- pytest tests/unit/test_pfpl_evaluate.py


------
https://chatgpt.com/codex/tasks/task_e_68e342517c9c83298b24844cd3942e2e