### PR TITLE
fix: ensure PFPL guards preserve decision logging

### DIFF
--- a/src/bots/pfpl/strategy.py
+++ b/src/bots/pfpl/strategy.py
@@ -89,6 +89,47 @@ def _coerce_bool(value: Any, *, default: bool) -> bool:
 class PFPLStrategy:
     """Price-Fair-Price-Lag bot"""
 
+    # 役割: クールダウンと1秒あたりの最大発注数を守る（簡易レートリミット）
+    def _can_fire(self, now_ts: float) -> bool:
+        _logger = getattr(self, "log", None) or getattr(self, "logger", None)
+        if not hasattr(self, "_last_order_ts"):
+            self._last_order_ts = 0.0
+        if not hasattr(self, "_order_count_window_start"):
+            self._order_count_window_start = now_ts
+            self._order_count_in_window = 0
+
+        # クールダウン判定
+        cd = float(getattr(self, "cooldown_sec", 0.0) or 0.0)
+        if (now_ts - self._last_order_ts) < cd:
+            if _logger:
+                _logger.debug(
+                    f"skip: cooldown {(now_ts - self._last_order_ts):.2f}s < {cd:.2f}s"
+                )
+            return False
+
+        # 1秒窓の発注回数判定
+        if (now_ts - self._order_count_window_start) >= 1.0:
+            self._order_count_window_start = now_ts
+            self._order_count_in_window = 0
+        if self._order_count_in_window >= int(
+            getattr(self, "max_order_per_sec", 1) or 1
+        ):
+            if _logger:
+                _logger.debug("skip: rate_limit max_order_per_sec reached")
+            return False
+
+        return True
+
+    # 役割: 取引所の minSizeUsd が分かればそれ、無ければ設定値 min_usd を返す
+    def _effective_min_usd(self) -> float:
+        exch_min = getattr(self, "minSizeUsd", None)
+        if exch_min is None:
+            meta = getattr(self, "market_meta", None) or getattr(self, "exchange_meta", None)
+            if isinstance(meta, dict):
+                exch_min = meta.get("minSizeUsd")
+        fallback = float(getattr(self, "min_usd", 0.0) or 0.0)
+        return float(exch_min) if exch_min is not None else fallback
+
     # 役割: フィード辞書から対象銘柄の価格を取り出す。まず 'ETH-PERP' を探し、無ければ 'ETH'（self.feed_key）でフォールバックする
     def _get_from_feed(self, feed: dict[str, Any]) -> Any:
         if not feed:
@@ -290,6 +331,20 @@ class PFPLStrategy:
         self.base_coin = sym_parts[0] if sym_parts else self.symbol
         self.target_symbol = self.symbol
         self.feed_key = self.base_coin
+
+        # 役割: 起動時に一度だけ、現在の重要設定とパッチ状態を INFO ログへ出す（更新コードで起動したかを即判定）
+        _logger = getattr(self, "log", None) or getattr(self, "logger", None)
+        if _logger:
+            _logger.info(
+                f"boot: PFPLStrategy patch=perp_fallback+guards "
+                f"fair_feed={getattr(self,'fair_feed',None)} "
+                f"target={getattr(self,'target_symbol',None)} "
+                f"feed_key={getattr(self,'feed_key',None)} "
+                f"threshold={getattr(self,'threshold',None)} "
+                f"order_usd={getattr(self,'order_usd',None)} "
+                f"dry_run={getattr(self,'dry_run',None)} "
+                f"testnet={getattr(self,'testnet',None)}"
+            )
 
         max_ops = int(self.config.get("max_order_per_sec", 3))  # 1 秒あたり発注上限
         self.sem = semaphore or asyncio.Semaphore(max_ops)
@@ -734,6 +789,30 @@ class PFPLStrategy:
         if _logger:
             _logger.debug(f"edge(abs): {abs(mid - fair)} (edge={mid - fair})")
 
+        now_ts = time.time()
+        can_fire = self._can_fire(now_ts)
+
+        # ここで notion（USD）を見積もって最小発注額を満たすか確認する
+        order_usd = float(getattr(self, "order_usd", 0.0) or 0.0)
+        qty_tick = float(
+            getattr(self, "qtyTick", 0.0)
+            or getattr(self, "qty_tick", 0.0)
+            or 0.0
+        )
+        mid_float = float(mid) if mid else 0.0
+        qty_raw = order_usd / mid_float if mid_float else 0.0
+        qty = (int(qty_raw / qty_tick) * qty_tick) if qty_tick > 0 else qty_raw
+        notional = float(qty) * mid_float if mid_float else 0.0
+        min_needed = self._effective_min_usd()
+
+        _logger = getattr(self, "log", None) or getattr(self, "logger", None)
+        notional_ok = notional >= min_needed
+        if not notional_ok:
+            if _logger:
+                _logger.debug(
+                    f"skip: notional {notional:.2f} < min_usd {min_needed:.2f} (qty={qty})"
+                )
+
         diff = fair - mid  # USD 差（符号付き）
         diff_pct = diff / mid * Decimal("100")  # 乖離率 %（符号付き）
         abs_diff = abs(diff)
@@ -755,6 +834,10 @@ class PFPLStrategy:
             threshold_pct=th_pct,
             spread_threshold=spread_thr,
         )
+        if not can_fire:
+            return
+        if not notional_ok:
+            return
         mode = self.config.get("mode", "both")  # both / either
 
         if mode == "abs":
@@ -813,6 +896,11 @@ class PFPLStrategy:
             return
 
         # ⑨ 発注
+        # 役割: ここまで来たら「発注してOK」。カウンタだけ進め、既存の発注ロジックへ続行
+        self._last_order_ts = now_ts
+        self._order_count_in_window = (
+            getattr(self, "_order_count_in_window", 0) or 0
+        ) + 1
         asyncio.create_task(self.place_order(side, float(size)))
 
     # ---------------------------------------------------------------- order


### PR DESCRIPTION
## Summary
- add guard helpers on PFPL strategy to enforce cooldown and per-second order rate
- skip orders below effective min USD notional while logging the reason
- ensure cooldown and min-notional guards run after decision logging and only advance counters when an order is actually placed
- emit a boot beacon INFO log describing key PFPL strategy settings to confirm the patched code is running

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e4ded24f2c8329a358f713a737fbb9