### PR TITLE
Adjust PFPL boot beacon logging

### DIFF
--- a/src/bots/pfpl/strategy.py
+++ b/src/bots/pfpl/strategy.py
@@ -334,20 +334,6 @@ class PFPLStrategy:
 
         self.log = logging.getLogger(__name__)
 
-        # 役割: 起動時に一度だけ、現在の重要設定とパッチ状態を INFO ログへ出す（更新コードで起動したかを即判定）
-        _logger = getattr(self, "log", None) or getattr(self, "logger", None)
-        if _logger:
-            _logger.info(
-                f"boot: PFPLStrategy patch=perp_fallback+guards "
-                f"fair_feed={getattr(self,'fair_feed',None)} "
-                f"target={getattr(self,'target_symbol',None)} "
-                f"feed_key={getattr(self,'feed_key',None)} "
-                f"threshold={getattr(self,'threshold',None)} "
-                f"order_usd={getattr(self,'order_usd',None)} "
-                f"dry_run={getattr(self,'dry_run',None)} "
-                f"testnet={getattr(self,'testnet',None)}"
-            )
-
         max_ops = int(self.config.get("max_order_per_sec", 3))  # 1 秒あたり発注上限
         self.sem = semaphore or asyncio.Semaphore(max_ops)
 
@@ -473,10 +459,25 @@ class PFPLStrategy:
         self.dry_run = bool(self.config.get("dry_run"))
         self.max_pos = Decimal(self.config.get("max_position_usd", 100))
         self.fair_feed = self.config.get("fair_feed", "indexPrices")
+        self.testnet = bool(self.config.get("testnet"))
         self.max_daily_orders = int(self.config.get("max_daily_orders", 500))
         self._order_count = 0
         self._start_day = datetime.now(timezone.utc).date()
         self.enabled = True
+
+        # 役割: 起動時に一度だけ、現在の重要設定とパッチ状態を INFO ログへ出す（更新コードで起動したかを即判定）
+        _logger = getattr(self, "log", None) or getattr(self, "logger", None)
+        if _logger:
+            _logger.info(
+                "boot: PFPLStrategy patch=perp_fallback+guards "
+                f"fair_feed={self.fair_feed} "
+                f"target={self.target_symbol} "
+                f"feed_key={self.feed_key} "
+                f"threshold={self.config.get('threshold')} "
+                f"order_usd={self.order_usd} "
+                f"dry_run={self.dry_run} "
+                f"testnet={self.testnet}"
+            )
         # ── フィード保持用 -------------------------------------------------
         self.mid: Decimal | None = None  # 板 Mid (@1)
         self.idx: Decimal | None = None  # indexPrices


### PR DESCRIPTION
## Summary
- move the PFPL boot beacon log to emit after key configuration attributes are initialised
- log the configured threshold value directly from the strategy config
- persist the testnet flag on the strategy for reuse in logging

## Testing
- poetry run pytest -q -m "not live" --maxfail=1
- poetry run ruff check .

------
https://chatgpt.com/codex/tasks/task_e_68e62bc30da48329bb4f6a5764a7f202